### PR TITLE
change return value of authenticate; add id

### DIFF
--- a/lib/LibreCat/Auth/Bag.pm
+++ b/lib/LibreCat/Auth/Bag.pm
@@ -25,17 +25,21 @@ sub _authenticate {
 
     unless ($user) {
         $self->log->debug("$username not found");
-        return 0;
+        return undef;
     }
 
     if (exists $user->{$self->password_attr}
         && passwdcmp($password, $user->{$self->password_attr}))
     {
-        return 1;
+        return +{
+            uid => $username,
+            package => __PACKAGE__,
+            package_id => $self->id
+        };
     }
     else {
         $self->log->debug("$username password doesn't match");
-        return 0;
+        return undef;
     }
 }
 

--- a/lib/LibreCat/Auth/LDAP.pm
+++ b/lib/LibreCat/Auth/LDAP.pm
@@ -56,7 +56,7 @@ sub _authenticate {
 
     $self->log->debug(
         "username: $username ; password: " . length($password) . " bytes");
-    return 0 unless defined($username) & defined($password);
+    return undef unless defined($username) & defined($password);
 
     my $base = sprintf($self->auth_base, $username);
 
@@ -65,14 +65,15 @@ sub _authenticate {
 
     $self->log->error("...bind failed") unless $bind;
 
-    return 0 unless $bind;
+    return undef unless $bind;
 
     $self->log->debug("...code " . $bind->code . ": error: " . $bind->error);
 
     $self->log->debug("unbind");
     $self->ldap->unbind;
 
-    $bind->code == Net::LDAP::LDAP_SUCCESS ? 1 : 0;
+    $bind->code == Net::LDAP::LDAP_SUCCESS ?
+        +{ uid => $username, package => __PACKAGE__, package_id => $self->id } : undef;
 }
 
 # TODO use exception objects

--- a/lib/LibreCat/Auth/Multi.pm
+++ b/lib/LibreCat/Auth/Multi.pm
@@ -25,9 +25,10 @@ sub _build_auths {
 sub _authenticate {
     my ($self, $params) = @_;
     for my $auth (@{$self->_auths}) {
-        $auth->authenticate($params) && return 1;
+        my $res = $auth->authenticate($params);
+        return $res if $res;
     }
-    0;
+    undef;
 }
 
 1;

--- a/lib/LibreCat/Auth/SSO.pm
+++ b/lib/LibreCat/Auth/SSO.pm
@@ -22,6 +22,12 @@ has authorization_url => (
     default => sub { '/' },
     required => 1
 );
+has id => (
+    is => 'ro',
+    lazy => 1,
+    required => 1,
+    default => sub{ __PACKAGE__ }
+);
 requires 'to_app';
 
 #check if $env->{psgix.session} is stored Plack::Session->session
@@ -80,7 +86,7 @@ LibreCat::Auth::SSO - LibreCat role for Single Sign On (SSO) authentication
             #..
 
             #everything ok: set auth_sso
-            $self->set_auth_sso( $session, { type => "MySSOAuth", response => "Long response from external SSO application" }
+            $self->set_auth_sso( $session, { package => __PACKAGE__, package_id => $self->id, response => "Long response from external SSO application" } );
 
             #redirect to other application for authorization:
             return [302,[Location => $self->authorization_url],[]];
@@ -148,7 +154,8 @@ from the SSO application in this session key.
 The response should look like this:
 
     {
-        type => "<impl>",
+        package => "<package-name>",
+        package_id => "<package-id>",
         response => "Long response from external SSO application like CAS"
     }
 
@@ -163,6 +170,12 @@ This is usefull for two reasons:
 URL of the authorization route.
 
 When authentication succeeds, this application should redirect you here
+
+=item id
+
+identifier of the authentication module. Defaults to the package name.
+This is handy when using multiple SSO instances, and you need to known
+exactly which package authenticated the user.
 
 =back
 
@@ -185,7 +198,7 @@ save SSO response to your session
 $hash should be a hash ref, and look like this:
 
 
-    { type => "$type", response => "Long response from external SSO application like CAS" }
+    { package => __PACKAGE__, package_id => __PACKAGE__ , response => "Long response from external SSO application like CAS" }
 
 =head1 SEE ALSO
 

--- a/lib/LibreCat/Auth/SSO/CAS.pm
+++ b/lib/LibreCat/Auth/SSO/CAS.pm
@@ -64,7 +64,7 @@ sub to_app {
                 my $doc = $r->doc();
                 $doc = $doc->toString();
 
-                $self->set_auth_sso($session,{ type => "CAS", response => $doc });
+                $self->set_auth_sso($session,{ package => __PACKAGE__, package_id => $self->id, response => $doc });
 
                 return [302,[Location => $self->authorization_url],[]];
 

--- a/lib/LibreCat/Auth/SSO/ORCID.pm
+++ b/lib/LibreCat/Auth/SSO/ORCID.pm
@@ -85,7 +85,7 @@ sub to_app {
 
             }
 
-            $self->set_auth_sso($session,{ type => "ORCID", response => $res->content });
+            $self->set_auth_sso($session,{ package => __PACKAGE__, package_id => $self->id, response => $res->content });
 
             return [302,[Location => $self->authorization_url],[]];
         }


### PR DESCRIPTION
Changes:

* return value of LibreCat::Auth: hash or undef. So it is still the same in a boolean context.
* return value of LibreCat::Auth returns information about the module and the user:

```
{
    uid => "njfranck",
    package => "LibreCat::Auth::Bag",
    package_id => "LibreCat::Auth::Bag"
}
```

* add method "id" to LibreCat::Auth. Defaults to the package name. This is usefull when using
  multiple instances of the same package in LibreCat::Auth::Multi, and the application
  needs to know which package succeeded. This is "id" is stored in the key "package_id" of the returned hash.
* add method "id" to LibreCat::Auth::SSO
* LibreCat::Auth::SSO now stores similar hash in session as LibreCat::Auth (with the addition of "response")