### PR TITLE
fix id for LibreCat::Auth::SSO

### DIFF
--- a/lib/LibreCat/Auth/SSO.pm
+++ b/lib/LibreCat/Auth/SSO.pm
@@ -22,13 +22,12 @@ has authorization_url => (
     default => sub { '/' },
     required => 1
 );
-has id => (
-    is => 'ro',
-    lazy => 1,
-    required => 1,
-    default => sub{ __PACKAGE__ }
-);
+has id => ( lazy => 1 );
 requires 'to_app';
+
+sub _build_id {
+    ref($_[0]);
+}
 
 #check if $env->{psgix.session} is stored Plack::Session->session
 sub _check_plack_session {


### PR DESCRIPTION
Now the id is also fixed in LibreCat::Auth::SSO, which is a totally different base package.