### PR TITLE
Change department display name

### DIFF
--- a/views/person/hits.tt
+++ b/views/person/hits.tt
@@ -24,7 +24,7 @@
 <dt><a href="/person/[% person._id %]">[% person.full_name %][% IF person.idm_title %], [% person.idm_title %][% END %] ([% person.publication_hits %] [% lf.tabs.publications %][% IF person.research_hits %], [% person.research_hits %] [% lf.tabs.data_publications %][% END %])</a></dt>
 <dd>
   [% FOREACH affil IN person.department %]
-<span class="text-muted">[% h.get_department(affil._id).name %]</span>[% IF !loop.last %], [% END %]
+<span class="text-muted">[% h.get_department(affil._id).display %]</span>[% IF !loop.last %], [% END %]
   [% END %]
 </dd>
 [% END %]


### PR DESCRIPTION
Important because `name` could contain strings for order (see
https://github.com/LibreCat/LibreCat/wiki/Import-Departments#tree-displa
y-sorting)