### PR TITLE
Update crossref_mapping.fix

### DIFF
--- a/fixes/crossref_mapping.fix
+++ b/fixes/crossref_mapping.fix
@@ -38,7 +38,7 @@ end
 add_field(publication_status, published)
 
 # type mapping
-if all_match('type','journal-article')
+if all_match('type','journal_article')
     set_field('type','journal_article')
     move_field('container-title.0','publication')
     if any_match(page, '-')


### PR DESCRIPTION
Change the `-` to `_` since this is hard coded in line 9. Might help to solve #200. Now the `publication` field is populated correctly.