### PR TITLE
Update crossref_mapping.fix

### DIFF
--- a/fixes/crossref_mapping.fix
+++ b/fixes/crossref_mapping.fix
@@ -71,3 +71,6 @@ remove_field(issued)
 remove_field(member)
 remove_field(container-title)
 remove_field(funder)
+if is_number(year)
+   capitalize(year)
+end


### PR DESCRIPTION
This change fixes an issue, that is documented [here](https://github.com/subugoe/goefis/issues/115). This is a typing error (integer instead of string), we 'reuse' `capitalize()` as the Catmandu documentation doesn't show a easy way to do type casts (it seems there is even a concept of data typing missing).