### PR TITLE
csl is optional

### DIFF
--- a/config/citation.yml
+++ b/config/citation.yml
@@ -3,7 +3,7 @@ _prefix:
 
 # engine for citation generation
 # possible values are 'csl' or 'none'
-engine: no
+engine: none
 
 # example 'csl' style citation generation
 # see: https://github.com/LibreCat/LibreCat/wiki/Citation-Style-Language

--- a/config/citation.yml
+++ b/config/citation.yml
@@ -3,7 +3,7 @@ _prefix:
 
 # engine for citation generation
 # possible values are 'csl' or 'none'
-engine: csl
+engine: no
 
 # example 'csl' style citation generation
 # see: https://github.com/LibreCat/LibreCat/wiki/Citation-Style-Language


### PR DESCRIPTION
The Citation Style Language is marked as optional, so the default setting should be "no".