### PR TITLE
Catmandu::BagIt::Payload uses method open

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -107,7 +107,7 @@ requires 'Path::Tiny', '0.052';
 requires 'String::CamelCase';
 
 requires 'MIME::Types','==1.38';
-requires 'Catmandu::BagIt' , '>=0.12';
+requires 'Catmandu::BagIt' , '>=0.13';
 
 requires 'Catmandu::Store::FedoraCommons';
 requires 'IO::All';

--- a/lib/LibreCat/FileStore/Container/BagIt.pm
+++ b/lib/LibreCat/FileStore/Container/BagIt.pm
@@ -52,9 +52,9 @@ sub get {
 
     return undef unless $file;
 
-    my $data = $file->fh;
+    my $data = $file->open();
     my $md5  = $bagit->get_checksum($key);
-    my $stat = [$file->fh->stat];
+    my $stat = [$data->stat()];
 
     my $size     = $stat->[7];
     my $modified = $stat->[9];


### PR DESCRIPTION
The test
```
t/LibreCat/FileStore/BagIt.t
```
failed with this error
```
Can't locate object method "fh" via package "Catmandu::BagIt::Payload" at /home/travis/build/LibreCat/LibreCat/lib/LibreCat/FileStore/Container/BagIt.pm line 55
```

cf. https://travis-ci.org/LibreCat/LibreCat/jobs/262160815

Starting from version 0.13 Catmandu::BagIt::Payload doesn't have the method "fh" anymore
(It caused the error "too many open files" due to preloading these file handles), but instead
uses the method "open" to explicitly open these "files".

Librecat required version 0.12 or above. Changed this to 0.13.