### PR TITLE
Feature/display all main file links

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -238,6 +238,7 @@ frontdoor:
       title: "Titel"
       description: "Beschreibung"
       url: "URL"
+      main_file_link: "Link(s) zu Volltext(en)"
       access_level:
         label: "Access Level"
         open_access: "Open Access"

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -237,6 +237,7 @@ frontdoor:
       title: "File Title"
       description: "Description"
       url: "URL"
+      main_file_link: "Link(s) to Main File(s)"
       access_level:
         label: "Access Level"
         open_access: "Open Access"

--- a/views/publication/record.tt
+++ b/views/publication/record.tt
@@ -190,7 +190,7 @@
       <div class="col-md-12">
         <ul class="nav nav-tabs">
           <li class="active"><a href="#details" data-toggle="tab">[% h.loc("frontdoor.tabs.details.label") %]</a></li>
-          [% IF (mainFile AND mainFile.size) OR (relFile AND relFile.size) %]
+          [% IF mainFile AND mainFile.size OR relFile AND relFile.size OR main_file_link AND main_file_link.size %]
           <li><a href="#fileDetails" data-toggle="tab">[% h.loc("frontdoor.tabs.file_details.label") %]</a></li>
           [% END %]
 
@@ -232,7 +232,7 @@
 
           [% PROCESS publication/tab_details.tt %]
 
-          [% IF file AND file.size %] [% PROCESS publication/tab_filedetails.tt %] [% END %]
+          [% IF file AND file.size OR relFile AND relFile.size OR main_file_link AND main_file_link.size %] [% PROCESS publication/tab_filedetails.tt %] [% END %]
 
           [% IF relPubl %] [% PROCESS publication/tab_relpubl.tt %] [% END %]
 

--- a/views/publication/tab_filedetails.tt
+++ b/views/publication/tab_filedetails.tt
@@ -103,7 +103,6 @@
   [% END %] <!-- IF mainFile -->
 
   [% IF relFile %]
-
   [% j = 0 %]
   [% FOREACH fi IN file %]
   [% NEXT IF fi.relation == "main_file" OR fi.relation == "hidden" OR fi.relation == "confirmation" %]
@@ -170,6 +169,38 @@
   [% j = j+1 %]
   [% END %] <!-- FOREACH -->
   [% END %] <!-- IF relFile -->
+
+  [% IF main_file_link.size %]
+
+  [% j = 0 %]
+  [% FOREACH fi IN main_file_link %]
+  <div class="row[% UNLESS j == 0 %] margin-top1[% END %]">
+    <div class="col-md-12">
+      <strong>[% h.loc("frontdoor.tabs.file_details.main_file_link") %]</strong>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3 text-muted">[% h.loc("frontdoor.tabs.file_details.url") %]</div>
+    <div class="col-md-9">
+      <a href="[% fi.url | uri %]">
+        [% fi.url | html %]
+      </a>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-md-3 text-muted">[% h.loc("frontdoor.tabs.file_details.access_level.label") %]</div>
+    <div class="col-md-9">
+      [% IF fi.open_access %]
+        <img src="[% uri_base %]/images/access_open.png" class="description" data-toggle="tooltip" data-html="true" data-placement="bottom" rel="tooltip" title="Open access file" alt="OA"> [% h.loc("frontdoor.tabs.file_details.access_level.open_access") %]
+      [% ELSE %]
+        <img src="[% uri_base %]/images/access_restricted.png" class="description" data-toggle="tooltip" data-html="true" data-placement="bottom" rel="tooltip" title="Restricted access for author/reviewer only." alt="Restricted"> [% h.loc("frontdoor.tabs.file_details.access_level.closed") %]
+      [% END %]
+    </div>
+  </div>
+  [% j = j+1 %]
+  [% END %] <!-- FOREACH -->
+
+  [% END %] <!-- IF main_file_link -->
 </div><!-- tab-pane fileDetails -->
 
 <!-- END publication/tab_filedetails.tt -->


### PR DESCRIPTION
Display all main_file_links on frontdoor (record.tt).
Links are now all displayed on tab file_details below any fulltext download links. In the upper section of the frontdoor still only the first url is dispayed.