### PR TITLE
Fix citation styles in embed view

### DIFF
--- a/views/embed/iframe.tt
+++ b/views/embed/iframe.tt
@@ -1,6 +1,7 @@
 [% qp = request.params.hash -%]
 [% qp.delete('splat') -%]
 [% lf = h.config.locale.$lang -%]
+[% style = qp.style ? qp.style : h.config.citation.csl.default_style -%]
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
The embed template does not set the style variable, therefore no citation styles (and also not the default style) are applied to the view. The variable is now added as in views/publication/list.tt