### PR TITLE
Fix typo in language key

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -230,6 +230,7 @@ frontdoor:
       investigator: "Leiter"
       member: "Mitglieder"
       cooperator: "Mitwirkende"
+      grant_number: "Bewilligungsnummer"
     file_details:
       label: "Dateien"
       external_material: "Externes Material:"

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -229,6 +229,7 @@ frontdoor:
       investigator: "Principal Investigator"
       member: "Member"
       cooperator: "Cooperator"
+      grant_number: "Grant Number"
     file_details:
       label: "Files"
       external_material: "External material:"

--- a/views/project/record.tt
+++ b/views/project/record.tt
@@ -40,7 +40,7 @@
       <div class="col-md-12">
 	    <ul class="nav nav-tabs">
 	      <li class="active"><a href="#project_details" data-toggle="tab">[% h.loc("frontdoor.tabs.details.label") %]</a></li>
-          [%- IF project_publication %]<li><a href="#project_publications" data-toggle="tab">[% h.loc("tabs.publication") %]</a></li>[% END %]
+          [%- IF project_publication %]<li><a href="#project_publications" data-toggle="tab">[% h.loc("tabs.publications") %]</a></li>[% END %]
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Here, publication is written in singular, in the language file it is the plural. Since the plural makes more sense, I changed it here.