### PR TITLE
Handling language in embed views through request parameter

### DIFF
--- a/views/embed/iframe.tt
+++ b/views/embed/iframe.tt
@@ -1,5 +1,6 @@
 [% qp = request.params.hash -%]
 [% qp.delete('splat') -%]
+[% lang = qp.lang ? qp.lang : h.config.default_lang -%]
 [% lf = h.config.locale.$lang -%]
 [% style = qp.style ? qp.style : h.config.citation.csl.default_style -%]
 <!DOCTYPE html>

--- a/views/embed/javascript.tt
+++ b/views/embed/javascript.tt
@@ -1,5 +1,7 @@
 <!-- BEGIN embed/javascript.tt -->
-[% qp = request.params.hash %]
+[% qp = request.params.hash -%]
+[% lang = qp.lang ? qp.lang : h.config.default_lang -%]
+[% lf = h.config.locale.$lang -%]
 document.write ('<ul[% IF qp.listyle %] style="[% qp.listyle %]"[% END %]>') ;
 [%- style = qp.style %]
 [%- FOREACH entry IN hits %]

--- a/views/filters.tt
+++ b/views/filters.tt
@@ -209,6 +209,8 @@ $('#id_button_embed_[% tabmodus %][% menu %]').click(function() {
     }
 
     embed_link = embed_link + $.param($.extend({}, searchParams), true);
+    
+    embed_link = embed_link + '&lang=[% lang %]';
 
     var emb_js     = '<div class="publ"><script type="text/javascript" charset="UTF-8" src="'+ embed_link +'&fmt=js"><\/script><noscript><a href="'+ embed_link +'" target="_blank">[% h.loc("facets.embed_linktext") %]</a></noscript></div>';
     var emb_iframe = '<iframe id="pubIFrame" name="pubIFrame" frameborder="0" width="726" height="300" src="' + embed_link + '&fmt=iframe"></iframe>';


### PR DESCRIPTION
Handling the language through a session doesn't make so much sense in embed views:
- Many users see the embed page only once, since it is embedded in a different page and not in the librecat system.
- The context of the embed page is an arbitrary web page which often has a predefined language. So for a good user experience the embedded view should have the same language as the parent page.
- In an embedded view, the user has no possibility to change the language.

I propose to handle the language (only for embedded views) through a request parameter, similar to the style.