### PR TITLE
Change doi.org urls to https

### DIFF
--- a/t/LibreCat/FetchRecord/crossref.t
+++ b/t/LibreCat/FetchRecord/crossref.t
@@ -26,7 +26,7 @@ SKIP: {
     }
 
     my @dois = (
-        "doi:10.1002/0470841559.ch1", "http://doi.org/10.1002/0470841559.ch1"
+        "doi:10.1002/0470841559.ch1", "https://doi.org/10.1002/0470841559.ch1"
     );
     for (@dois) {
         my $pub = $x->fetch($_);

--- a/views/backend/generator/fields/external_file.tt
+++ b/views/backend/generator/fields/external_file.tt
@@ -11,7 +11,7 @@
         <div class="checkbox">
           <label class="checkbox-inline">
             <input type="checkbox" value="1" name="external_file"[% IF external_file == "1" %] checked="checked"[% END %] />
-            [% h.loc("forms.${type}.field.external_file.checkbox") %] <strong><a href="http://doi.org/[% doi %]" target="_blank">[% doi %]</a></strong>
+            [% h.loc("forms.${type}.field.external_file.checkbox") %] <strong><a href="https://doi.org/[% doi %]" target="_blank">[% doi %]</a></strong>
           </label>
         </div>
       </div>

--- a/views/header.tt
+++ b/views/header.tt
@@ -18,7 +18,7 @@
       [%- IF year %]<meta name="citation_date" content="[% year | html %]">[% END %]
       [%- IF file %][% FOREACH fi IN file %][% IF fi.file_name %]
       <meta name="citation_pdf_url" content="[% uri_base %]/download/[% _id %]/[% fi.file_id %]/[% fi.file_name | uri %]">[% END %][% END %][% END %]
-      [%- IF doi %]<meta name="citation_pdf_url" content="http://doi.org/[% doi | html %]">[% ELSIF link %]<meta name="citation_pdf_url" content="[% link.0.url | html %]">[% END %]
+      [%- IF doi %]<meta name="citation_pdf_url" content="https://doi.org/[% doi | html %]">[% ELSIF link %]<meta name="citation_pdf_url" content="[% link.0.url | html %]">[% END %]
       [%- IF publication %]<meta name="citation_journal_title" content="[% publication | html %]" />[% END %]
       [%- IF volume %]<meta name="citation_volume" content="[% volume | html %]" />[% END %]
       [%- IF issue %]<meta name="citation_issue" content="[% issue | html %]" />[% END %]
@@ -37,7 +37,7 @@
       [%- FOREACH rel_entry IN entry.host %][% IF rel_entry.issn %]<meta name="DC.source.ISSN" content="[% rel_entry.issn.0 | html %]">[% END %][% IF rel_entry.isbn %]<meta name="DC.source.ISBN" content="[% rel_entry.isbn.0 | html %]">[% END %][% END %]
       [%- lowtype = type.lower %]
       <meta name="DC.type" content="[% h.get_list('gs_doc_type').$lowtype %]">
-      [%- IF doi %]<link rel="DC.relation" href="http://doi.org/[% doi | html %]">[% END %]
+      [%- IF doi %]<link rel="DC.relation" href="https://doi.org/[% doi | html %]">[% END %]
       [%- IF urn %]<link rel="DC.relation" href="http://nbn-resolving.de/[% urn | html %]">[% END %]
       [%- IF publication_identifier.issn.0 %]<link rel="DC.relation" href="urn:ISSN:[% publication_identifier.issn.0 | html %]">[% END %]
       [%- IF publication_identifier.isbn.0 %]<link rel="DC.relation" href="urn:ISBN:[% publication_identifier.isbn.0 | html %]">[% END %]

--- a/views/links.tt
+++ b/views/links.tt
@@ -23,7 +23,7 @@
 
   [% FOREACH supp IN entry.related_material %][% IF supp.link  %] | <a href="[% supp.link.url %]" title="[% supp.link.title %]">Suppl. Material</a>[% ELSIF supp.file %] | <a href="[% uri_base %]/download/[% entry._id  %]/[% supp.file.file_id %]/[% supp.file.file_name | uri %]" title="[% supp.file.file_name %]">Suppl. Material</a> [% END %][% END %]
 
-  [% IF entry.doi %]| <a href="http://doi.org/[% entry.doi %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>DOI</a>[% END %]
+  [% IF entry.doi %]| <a href="https://doi.org/[% entry.doi %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>DOI</a>[% END %]
   [% IF entry.external_id.isi %] | <a href="http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&amp;rft_id=info:ut/[% entry.external_id.isi %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>WoS</a>[% END %]
   [% IF entry.external_id.pmid %] | <a href="http://www.ncbi.nlm.nih.gov/pubmed/[% entry.external_id.pmid %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>PubMed</a> | <a href="http://europepmc.org/abstract/MED/[% entry.external_id.pmid %]">Europe PMC</a>[% END %]
   [% IF entry.external_id.arxiv %] | <a href="http://arxiv.org/abs/[% entry.external_id.arxiv %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>arXiv</a>[% END %]

--- a/views/publication/record.tt
+++ b/views/publication/record.tt
@@ -143,7 +143,7 @@
         [%- IF doi %]
         <div class="row">
           <div class="col-xs-2 text-muted">[% h.loc("forms.${type}.field.doi.label") %]</div>
-          <div class="col-xs-10"><a itemprop="url" href="http://doi.org/[% doi %]" title="[% doi %]">[% doi | html %]</a></div>
+          <div class="col-xs-10"><a itemprop="url" href="https://doi.org/[% doi %]" title="[% doi %]">[% doi | html %]</a></div>
         </div>
         [%- END %]
         [%- IF urn %]


### PR DESCRIPTION
The preferred way to access the proxy server at doi.org is through https (see http://www.doi.org/factsheets/DOIProxy.html) which is also the better alternative for improving security in the whole web.