### PR TITLE
Increase column width because of longer ids

### DIFF
--- a/views/admin/project.tt
+++ b/views/admin/project.tt
@@ -49,7 +49,7 @@
 
     [% FOREACH p IN hits %]
     <div class="row innerrow">
-      <div class="col-md-1">
+      <div class="col-md-3">
 	<a href="[% uri_base %]/project/[% p._id %]"><span class="label label-success"><strong>[% p._id %]</strong></span></a>
       </div>
       <div class="col-md-9">

--- a/views/admin/research_group.tt
+++ b/views/admin/research_group.tt
@@ -49,7 +49,7 @@
 
     [% FOREACH p IN hits %]
     <div class="row innerrow">
-      <div class="col-md-1">
+      <div class="col-md-3">
 	<a href="[% uri_base %]/research_group/[% p._id %]"><span class="label label-success"><strong>[% p._id %]</strong></span></a>
       </div>
       <div class="col-md-9">


### PR DESCRIPTION
The length of the ids are no longer fitting in the column with class col-md-1 (see http://demo.librecat.org/librecat/admin/research_group). Therefore, I've increased them to col-md-3. No other column width has to be decreased, because the total supported width in bootstrap is 12.