### PR TITLE
 Fix language key for editor label

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -729,7 +729,7 @@ forms:
     label: "Konferenzband"
     tab: *tab
     field:
-      editor.label: "Herausgeber"
+      editor: "Herausgeber"
       document_type: *document_type
       doi: *doi
       title: *booktitle

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -728,7 +728,7 @@ forms:
     label: "Conference (Editor)"
     tab: *tab
     field:
-      editor.label: "Editor"
+      editor: "Editor"
       document_type: *document_type
       doi: *doi
       title: *booktitle


### PR DESCRIPTION
.label already added in the html template (see https://github.com/LibreCat/LibreCat/blob/master/views/publication/tab_details.tt)