### PR TITLE
Redirect to previous page after udpating a record

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -152,6 +152,7 @@ Checks if the user has the rights to update this record.
 
     post '/update' => sub {
         my $p = params;
+        my $return_url = $p->{return_url};
 
         h->log->debug("Params:" . to_dumper($p));
 
@@ -189,7 +190,7 @@ Checks if the user has the rights to update this record.
             }
         );
 
-        redirect uri_for('/librecat');
+        redirect $return_url || uri_for('/librecat');
     };
 
 =head2 GET /return/:id

--- a/views/backend/generator/master.tt
+++ b/views/backend/generator/master.tt
@@ -37,6 +37,7 @@
     <input type="hidden" name="creator.login" value="[% creator ? creator.login : thisPerson.login %]" />
     <input type="hidden" name="creator.id" value="[% creator ? creator.id : thisPerson._id %]" />
     <input type="hidden" name="edit_mode" id="edit_mode" value="expert" />
+    <input type="hidden" name="return_url" id="return_url" value="[% return_url || uri_base _ '/librecat' %]" />
 
     <div class="tab tab-content edit-form">
       {% INCLUDE fields/buttonrow_tab.tt %}

--- a/views/backend/generator/master.tt
+++ b/views/backend/generator/master.tt
@@ -37,7 +37,7 @@
     <input type="hidden" name="creator.login" value="[% creator ? creator.login : thisPerson.login %]" />
     <input type="hidden" name="creator.id" value="[% creator ? creator.id : thisPerson._id %]" />
     <input type="hidden" name="edit_mode" id="edit_mode" value="expert" />
-    <input type="hidden" name="return_url" id="return_url" value="[% return_url || uri_base _ '/librecat' %]" />
+    <input type="hidden" name="return_url" id="return_url" value="[% return_url %]" />
 
     <div class="tab tab-content edit-form">
       {% INCLUDE fields/buttonrow_tab.tt %}


### PR DESCRIPTION
The current behavior is the following: If I reach the edit page of a publication entry from any page (especially from a filtered search), the redirection after the edit is inconsistent:

- If I cancel the edit, I am redirected to the previous page (for example a filtered search).
- If I save the edit, I am always redirected to the default /librecat page.

The second behvior is quite annoying, especially if I do some mass edit for several events. Since I am for example editing different publications on page 10 of a filtered query. So after each edit, I have to filter again and click forward until I reach page 10.

To solve this problem, I have stored the return url (which is also used for the cancel button) in a hidden input field and after the update, I use this parameter as redirect target.