### PR TITLE
use JSON.Escape explicitly, not just when by accident included by oth…

### DIFF
--- a/views/mark_all_js.tt
+++ b/views/mark_all_js.tt
@@ -1,3 +1,4 @@
+[%- USE JSON.Escape %]
 <script>
 var path = '[% request.uri_for(request.path_info) %]',
 searchParams = [% h.extract_params.json %];


### PR DESCRIPTION
view/mark_all_js.tt sometimes produces invalid javascript:

```
searchParams = ;
```

because the template variable is encoded to json.
In some cases the current version works, but only because the previous included
views have already required the plugin JSON.Escape.