### PR TITLE
Fixing #402 file_date_updated added on indexation time

### DIFF
--- a/config/store.yml
+++ b/config/store.yml
@@ -201,6 +201,8 @@ search:
               field: 'project_type'
 
       publication:
+        fix:
+            - file_date_updated()
         cql_mapping:
           default_index: basic
           indexes:
@@ -545,7 +547,7 @@ search:
                 '=': true
                 'exact': true
                 '<>': true
-              field: 'file.date_updated'
+              field: 'file_date_updated'
               sort: true
               values: "date in the form yyyy-MM-ddTHH:mm:ssZ"
             publication_status: &publication_status
@@ -1054,6 +1056,7 @@ search:
           pubmed: {type: byte}
           inspire: {type: byte}
           scoap3: {type: byte}
+          file_date_updated: {type: date, format: date_time_no_millis}
           file:
             properties:
               access_level: {type: string, analyzer: tag}

--- a/lib/Catmandu/Fix/file_date_updated.pm
+++ b/lib/Catmandu/Fix/file_date_updated.pm
@@ -1,0 +1,48 @@
+package Catmandu::Fix::file_date_updated;
+
+use Catmandu::Sane;
+use POSIX qw(floor);
+use Moo;
+
+sub fix {
+    my ($self, $data) = @_;
+
+    my @dates = ();
+
+    for my $file (@{ $data->{file} }) {
+	    my $date_updated = $file->{date_updated};
+	    push @dates , $date_updated;
+    }
+
+    $data->{file_date_updated} = [ sort @dates ]->[-1] if @dates;
+
+    $data;
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+file_date_updated - calculate the latest update date of record files
+
+=head1 SYNOPSIS
+
+    # A new field file_date_updated will be created in the
+    # record with the latest update date for files at indexation time
+
+    # In store.yml section search.options.bags:
+
+    publication:
+      fix:
+          - file_date_updated()
+      cql_mapping:
+          ...
+
+    # Search for files updates after a date
+    $ bin/librecat publication list "file_date_updated > 2017-01-01T00:00:00Z"
+    
+=cut

--- a/lib/Catmandu/Fix/file_date_updated.pm
+++ b/lib/Catmandu/Fix/file_date_updated.pm
@@ -44,5 +44,5 @@ file_date_updated - calculate the latest update date of record files
 
     # Search for files updates after a date
     $ bin/librecat publication list "file_date_updated > 2017-01-01T00:00:00Z"
-    
+
 =cut


### PR DESCRIPTION
Calculates the latest update date of record files. Need an `./index.sh reindex` to become active