### PR TITLE
Solves #411

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/file.pm
+++ b/lib/LibreCat/App/Catalogue/Route/file.pm
@@ -262,12 +262,10 @@ and user rights will be checked before.
 get qr{/download/([0-9A-F-]+)/([0-9A-F-]+).*} => sub {
     my ($id, $file_id) = splat;
 
-    my $user = h->get_person(session->{user_id});
-
     my ($ok, $file_name) = p->can_download(
         $id, {
             file_id => $file_id,
-            user => $user,
+            user_id =>session->{user_id},
             role => session->{role},
             ip   => request->address
         }

--- a/lib/LibreCat/App/Catalogue/Route/file.pm
+++ b/lib/LibreCat/App/Catalogue/Route/file.pm
@@ -265,7 +265,7 @@ get qr{/download/([0-9A-F-]+)/([0-9A-F-]+).*} => sub {
     my ($ok, $file_name) = p->can_download(
         $id, {
             file_id => $file_id,
-            user_id =>session->{user_id},
+            user_id => session->{user_id},
             role => session->{role},
             ip   => request->address
         }


### PR DESCRIPTION
can_download expects `user_id` in the opts parameter, the download method has filled the parameter `user` with the user object instead of the id. Therefore, the `user_id` parameter was not available in the can_download and all checks for user access resulted in a false result