### PR TITLE
 Fix translation strings for conference_editor

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -731,7 +731,7 @@ forms:
     label: "Konferenzband"
     tab: *tab
     field:
-      editor: "Herausgeber"
+      editor: *editor
       document_type: *document_type
       doi: *doi
       title: *booktitle

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -730,7 +730,7 @@ forms:
     label: "Conference (Editor)"
     tab: *tab
     field:
-      editor: "Editor"
+      editor: *editor
       document_type: *document_type
       doi: *doi
       title: *booktitle


### PR DESCRIPTION
The template accesses forms.conference_editor.field.editor.label which is not available, now it works through the already defined *editor