### PR TITLE
Use IDs for external sources in links correctly

### DIFF
--- a/fixes/to_aref.fix
+++ b/fixes/to_aref.fix
@@ -39,9 +39,9 @@ move_field(publication_identifier.isbn.*, res.dct_isPartOf.$append)
 prepend(res.dct_isPartOf.*, 'http://id.crossref.org/issn/')
 
 move_field(publication_identifier.urn, res.dct_identifier.$append)
-prepend(external_id.isi, 'UT:')
-move_field(external_id.isi, res.dct_identifier.$append)
-move_field(external_id.pmid, res.fabio_hasPubmedId)
+prepend(external_id.isi.0, 'UT:')
+move_field(external_id.isi.0, res.dct_identifier.$append)
+move_field(external_id.pmid.0, res.fabio_hasPubmedId)
 
 retain_field(res)
 #prepend(_id,"http://pub.de")

--- a/views/links.tt
+++ b/views/links.tt
@@ -23,10 +23,10 @@
   [% FOREACH supp IN entry.related_material %][% IF supp.link  %] | <a href="[% supp.link.url %]" title="[% supp.link.title %]">Suppl. Material</a>[% ELSIF supp.file %] | <a href="[% uri_base %]/download/[% entry._id  %]/[% supp.file.file_id %]/[% supp.file.file_name | uri %]" title="[% supp.file.file_name %]">Suppl. Material</a> [% END %][% END %]
 
   [% IF entry.doi %]| <a href="https://doi.org/[% entry.doi %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>DOI</a>[% END %]
-  [% IF entry.external_id.isi %] | <a href="http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&amp;rft_id=info:ut/[% entry.external_id.isi %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>WoS</a>[% END %]
-  [% IF entry.external_id.pmid %] | <a href="http://www.ncbi.nlm.nih.gov/pubmed/[% entry.external_id.pmid %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>PubMed</a> | <a href="http://europepmc.org/abstract/MED/[% entry.external_id.pmid %]">Europe PMC</a>[% END %]
-  [% IF entry.external_id.arxiv %] | <a href="http://arxiv.org/abs/[% entry.external_id.arxiv %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>arXiv</a>[% END %]
-  [% IF entry.external_id.inspire %] | <a href="http://inspirebeta.net/record/[% entry.external_id.inspire %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>Inspire</a>[% END %]
+  [% IF entry.external_id.isi %] | <a href="http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&amp;rft_id=info:ut/[% entry.external_id.isi.0 %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>WoS</a>[% END %]
+  [% IF entry.external_id.pmid %] | <a href="https://www.ncbi.nlm.nih.gov/pubmed/[% entry.external_id.pmid.0 %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>PubMed</a> | <a href="https://europepmc.org/abstract/MED/[% entry.external_id.pmid.0 %]">Europe PMC</a>[% END %]
+  [% IF entry.external_id.arxiv %] | <a href="https://arxiv.org/abs/[% entry.external_id.arxiv.0 %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>arXiv</a>[% END %]
+  [% IF entry.external_id.inspire %] | <a href="https://inspirehep.net/record/[% entry.external_id.inspire.0 %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>Inspire</a>[% END %]
 
 [% IF backend %]
   <br />

--- a/views/publication/record.tt
+++ b/views/publication/record.tt
@@ -313,11 +313,11 @@
 
 	    [%- IF external_id.pmid.0 %]
 	    <p><img src="[% uri_base %]/images/icon_pubmed.png" class="img-thumbnail" alt="">PMID: [% external_id.pmid.0 %]<br>
-	    <a href="http://www.ncbi.nlm.nih.gov/pubmed/[% external_id.pmid.0 %]">PubMed</a> | <a href="http://europepmc.org/abstract/MED/[% external_id.pmid.0 %]">Europe PMC</a></p>
+	    <a href="https://www.ncbi.nlm.nih.gov/pubmed/[% external_id.pmid.0 %]">PubMed</a> | <a href="https://europepmc.org/abstract/MED/[% external_id.pmid.0 %]">Europe PMC</a></p>
 	    [%- END %]
 
 	    [%- IF external_id.arxiv.0 %]
-	    <p><img src="[% uri_base %]/images/icon_arxiv.png" class="img-thumbnail" alt="">arXiv <a href="http://arxiv.org/abs/[% external_id.arxiv.0 %]">[% external_id.arxiv.0 %]</a></p>
+	    <p><img src="[% uri_base %]/images/icon_arxiv.png" class="img-thumbnail" alt="">arXiv <a href="https://arxiv.org/abs/[% external_id.arxiv.0 %]">[% external_id.arxiv.0 %]</a></p>
 	    [%- END %]
 
 	    [%- IF external_id.inspire.0 %]
@@ -325,7 +325,7 @@
 	    [%- END %]
 
 	    [%- IF external_id.scoap3.0 %]
-	    <p><img src="[% uri_base %]/images/icon_scoap3.ico" class="img-thumbnail" alt="">SCOAP3 <a href="http://repo.scoap3.org/record/[% external_id.scoap3.0 %]">[% external_id.scoap3.0 %]</a></p>
+	    <p><img src="[% uri_base %]/images/icon_scoap3.ico" class="img-thumbnail" alt="">SCOAP3 <a href="https://repo.scoap3.org/record/[% external_id.scoap3.0 %]">[% external_id.scoap3.0 %]</a></p>
 	    [%- END %]
 	  [%- END %]
     [%- END %]
@@ -340,7 +340,7 @@
             [% IF loop.first %]
             <img src="[% uri_base %]/images/icon_genbank.gif" class="img-thumbnail" alt=""><strong>GenBank</strong><br>
             [% END %]
-            <a href="http://www.ncbi.nlm.nih.gov/nuccore/[% id_entry %]">[% id_entry %]</a>
+            <a href="https://www.ncbi.nlm.nih.gov/nuccore/[% id_entry %]">[% id_entry %]</a>
             [% IF loop.count > 14 %]
             <span id="showGen">
               <br><a href="#supplements" onclick="ShowGenBankIDs();"><span class="fa fa-plus fw"></span>[% h.loc("frontdoor.show_all") %]</a>
@@ -366,9 +366,9 @@
         <!-- Search title in -->
         <h3>[% h.loc("frontdoor.search_this") %]</h3>
         <p>
-          <a href="http://scholar.google.com/scholar?q=allintitle%3A[% title | uri %]"><img src="[% uri_base %]/images/icon_gs.png" alt="" class="img-thumbnail">Google Scholar</a><br>
+          <a href="https://scholar.google.com/scholar?q=allintitle%3A[% title | uri %]"><img src="[% uri_base %]/images/icon_gs.png" alt="" class="img-thumbnail">Google Scholar</a><br>
           [%- IF publication_identifier.isbn %]
-          <a href="http://de.wikipedia.org/wiki/Spezial:ISBN-Suche/[% publication_identifier.isbn.0 %]"><img src="[% uri_base %]/images/icon_wikipedia.png" alt="" class="img-thumbnail">[% h.loc("frontdoor.isbn_search") %]</a><br>
+          <a href="https://de.wikipedia.org/wiki/Spezial:ISBN-Suche/[% publication_identifier.isbn.0 %]"><img src="[% uri_base %]/images/icon_wikipedia.png" alt="" class="img-thumbnail">[% h.loc("frontdoor.isbn_search") %]</a><br>
           [%- END %]
         </p>
       </div>

--- a/views/publication/tab_details.tt
+++ b/views/publication/tab_details.tt
@@ -199,12 +199,12 @@
     <div class="col-lg-10 col-md-9">[% ipc | html %]</div>
   </div>
 [%- END %]
-[%- IF ubi_funded OR external_id.scoap3 %]
+[%- IF ubi_funded OR external_id.scoap3.0 %]
   <div class="row">
     <div class="col-lg-2 col-md-3 text-muted">[% h.loc("frontdoor.tabs.details.financial_disclosure") %]</div>
     [%- IF ubi_funded %]
     <div class="col-lg-10 col-md-9">[% h.loc("frontdoor.tabs.details.ubi_funded") %]</div>
-    [%- ELSIF external_id.scoap3 %]
+    [%- ELSIF external_id.scoap3.0 %]
     <div class="col-lg-10 col-md-9">[% h.loc("frontdoor.tabs.details.scoap3") %]</div>
     [%- END %]
   </div>


### PR DESCRIPTION
IDs for external sources (for example arxiv) are stored in arrays. In the record detail view, they are used correctly with `external_id.arxiv.0` (see views/publication/record.tt), but in views/links.tt it was wrong.

Additionally I have change URLs to https if supported and updated the inspire link.