### PR TITLE
Add external URL to link list

### DIFF
--- a/views/links.tt
+++ b/views/links.tt
@@ -23,6 +23,7 @@
   [% FOREACH supp IN entry.related_material %][% IF supp.link  %] | <a href="[% supp.link.url %]" title="[% supp.link.title %]">Suppl. Material</a>[% ELSIF supp.file %] | <a href="[% uri_base %]/download/[% entry._id  %]/[% supp.file.file_id %]/[% supp.file.file_name | uri %]" title="[% supp.file.file_name %]">Suppl. Material</a> [% END %][% END %]
 
   [% IF entry.doi %]| <a href="https://doi.org/[% entry.doi %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>DOI</a>[% END %]
+  [% IF entry.main_file_link.0 %] | <a href="[% entry.main_file_link.0.url %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>URL</a>[% END %]
   [% IF entry.external_id.isi %] | <a href="http://ws.isiknowledge.com/cps/openurl/service?url_ver=Z39.88-2004&amp;rft_id=info:ut/[% entry.external_id.isi %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>WoS</a>[% END %]
   [% IF entry.external_id.pmid %] | <a href="http://www.ncbi.nlm.nih.gov/pubmed/[% entry.external_id.pmid %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>PubMed</a> | <a href="http://europepmc.org/abstract/MED/[% entry.external_id.pmid %]">Europe PMC</a>[% END %]
   [% IF entry.external_id.arxiv %] | <a href="http://arxiv.org/abs/[% entry.external_id.arxiv %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>arXiv</a>[% END %]


### PR DESCRIPTION
This change allows a good user experience for publications without DOI. Furthermore the link list is now consistent with the record details head area regarding the visible information.