### PR TITLE
Fix rendering of url link

### DIFF
--- a/views/publication/tab_filedetails.tt
+++ b/views/publication/tab_filedetails.tt
@@ -185,7 +185,7 @@
   <div class="row">
     <div class="col-md-3 text-muted">[% h.loc("frontdoor.tabs.file_details.url") %]</div>
     <div class="col-md-9">
-      <a href="[% fi.url | uri %]">
+      <a href="[% fi.url %]">
         [% fi.url | html %]
       </a>
     </div>


### PR DESCRIPTION
The previous solution with "| uri" produced a non-usable link. The new solution is the same as in /views/publication/record.tt