### PR TITLE
Add collapsable abstract to list view

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -91,6 +91,7 @@ main_page:
     audit: Audit
     clone: "Klonen"
     edit: "Editieren"
+    abstract: "Abstract"
     details: "Details"
     view_details: "Publikationsseite in LibreCat anzeigen (Frontdoor)"
     files: "Dateien verf&uuml;gbar"

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -90,6 +90,7 @@ main_page:
   links:
     clone: Clone
     edit: "Edit"
+    abstract: "Abstract"
     details: "Details"
     view_details: "Show complete bibliographic information and access options."
     files: "Files available"

--- a/views/backend/rec_abstract.tt
+++ b/views/backend/rec_abstract.tt
@@ -1,0 +1,17 @@
+<!-- BEGIN backend/rec_abstract.tt -->
+
+[% IF entry.abstract %]
+  <div id="[% tabmodus %]_[% entry.item('_id') %]_abstract" class="collapse margin-top1-4">
+    <div class="col-md-12">
+      <div class="col-md-2 text-muted">[% h.loc("main_page.links.abstract") %]</div>
+      <div class="col-md-10 cmark abstract">
+        [% FOREACH ab IN entry.abstract %]
+          [% UNLESS loop.first %]<br /><hr>[% END %]
+          [% ab.text | html %]
+        [% END %]
+      </div>
+    </dv>
+  </div>
+[% END %]
+
+<!-- END backend/rec_abstract.tt -->

--- a/views/backend/rec_details.tt
+++ b/views/backend/rec_details.tt
@@ -1,7 +1,7 @@
 
 <!-- BEGIN backend/rec_details.tt -->
 
-<div id="[% tabmodus %]_[% entry.item('_id') %]" class="collapse margin-top1-4">
+<div id="[% tabmodus %]_[% entry.item('_id') %]_details" class="collapse margin-top1-4">
 
 [% IF entry.author %]
   <div class="col-md-12">

--- a/views/hits.tt
+++ b/views/hits.tt
@@ -98,6 +98,7 @@
     [% INCLUDE links.tt %]
     [%- IF backend %]
     [% INCLUDE backend/rec_details.tt %]
+    [% INCLUDE backend/rec_abstract.tt %]
     [%- IF session.role == 'super_admin' %][% IF entry.message %]<p class="bg-success"><em>[% entry.message | html %]</em></p>[% END %][% END %]
     [%- END %]
   </div>

--- a/views/links.tt
+++ b/views/links.tt
@@ -34,8 +34,10 @@
   [% ELSE %]
   <strong>[% h.loc("main_page.links.edit") %]</strong>
   [% END %]
-  | <a data-toggle="collapse" href="#[% tabmodus %]_[% entry._id %]">[% h.loc("main_page.links.details") %]</a>
-
+  | <a data-toggle="collapse" href="#[% tabmodus %]_[% entry._id %]_details">[% h.loc("main_page.links.details") %]</a>
+  [% IF entry.abstract %]
+    | <a data-toggle="collapse" href="#[% tabmodus %]_[% entry._id %]_abstract">[% h.loc("main_page.links.abstract") %]</a>
+  [% END %]
   [% IF session.role == "super_admin" %]
   | <a href="[% uri_base %]/librecat/record/internal_view/[% entry._id %]" target="_blank">[% h.loc("main_page.links.internal_view") %]</a> | <a href="[% uri_base %]/librecat/record/clone/[% entry._id %]" target="_blank">[% h.loc("main_page.links.clone") %]</a>
    [% IF h.config.audit %]


### PR DESCRIPTION
This pull request provides a collapsable abstract div to the list of publications in the backend. Technically, it is implemented in the same way as the details div. The rendering of the abstract itself is done in the same way as in the details view. It results in the following view:

![image](https://user-images.githubusercontent.com/6943048/38420360-bc51e202-39a3-11e8-9ab0-fdf514044bae.png)
