### PR TITLE
Fix label for publication type on marked list

### DIFF
--- a/views/marked/list.tt
+++ b/views/marked/list.tt
@@ -2,7 +2,7 @@
 [% qp.delete('splat') %]
 [% lang = session.lang ? session.lang : h.config.default_lang %]
 [%- style = qp.style ? qp.style : h.config.citation.csl.default_style %]
-[% INCLUDE header.tt %]
+[% PROCESS header.tt %]
 
 <!-- BEGIN marked/list.tt -->
 <script src="[% uri_base %]/javascripts/jquery-sortable-min.js"></script>


### PR DESCRIPTION
The publication type is not visible on the marked list, instead you see only `2018 |  | LibreCat-ID:`  (it is missing between the two bars.
The reason is in the rendering in hits.tt: It uses the variable lf to translate the type. This variable is defined in header.tt. Almost all files use the header.tt through PROCESS. The marked list.tt uses the INCLUDE procedure instead. By using INCLUDE the variables (such as lf) are not available. Fixed the problem by using PROCESS also here.