### PR TITLE
Correct link rendering for closed and local access files

### DIFF
--- a/views/links.tt
+++ b/views/links.tt
@@ -1,5 +1,8 @@
 <!-- BEGIN links.tt -->
 [% bag = entry.type == "research_data" ? "data" : "publication" %]
+[%- ip = request.address %]
+[%- ip_range = h.config.ip_range %]
+[%- local_user = h.within_ip_range(ip, ip_range) %]
 <a href="[% uri_base %][% IF entry.status == "public" %]/[% bag %]/[% entry._id %][% ELSE %]/librecat/record/preview/[% entry._id %][% END %]" title="[% h.loc("main_page.links.view_details") %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>[% h.loc("main_page.links.details") %]</a>
   [% IF entry.type == "research_data" AND (entry.file || entry.related_material || entry.externalFiles == "1") %]
   | <a href="[% uri_base %][% IF entry.status == "public" %]/[% bag %]/[% entry._id %][% ELSE %]/librecat/record/preview/[% entry._id %][% END %]" class="label label-primary">[% h.loc("main_page.links.files") %]</a>
@@ -7,7 +10,7 @@
     [% display_file = [] %]
     [% counter = 0 %]
     [% FOREACH fi IN entry.file %]
-    [% IF fi.open_access AND fi.relation != "hidden" %][% counter = counter + 1 %][% display_file.push(fi) %][% END %]
+    [% IF (fi.access_level == "open_access" OR (fi.access_level == "local" AND local_user) OR (fi.access_level = "closed" AND p.can_edit( entry._id, user_id = session.user_id, role = session.role ))) AND fi.relation != "hidden" %][% counter = counter + 1 %][% display_file.push(fi) %][% END %]
     [% END %]
     [% IF counter > 1 %]
       | <a href="[% uri_base %][% IF entry.status == "public" %]/[% bag %]/[% entry._id %][% ELSE %]/librecat/record/preview/[% entry._id %][% END %]" class="label label-primary">[% h.loc("main_page.links.files") %]</a>
@@ -15,7 +18,7 @@
       | <a href="[% uri_base %]/download/[% entry._id %]/[% display_file.0.file_id %]/[% display_file.0.file_name | uri %]">[% display_file.0.file_name.match("(?i).pdf$") ? "PDF" : lf.main_page.links.file %]</a>
     [% END %]
   [% ELSIF entry.type != "research_data" AND entry.file AND entry.file.size == 1 %]
-    [% IF entry.file.0.open_access %]
+    [% IF entry.file.0.access_level == "open_access" OR (entry.file.0.access_level == "local" AND local_user) OR (entry.file.0.access_level = "closed" AND p.can_edit( entry._id, user_id = session.user_id, role = session.role )) %]
     | <a href="[% uri_base %]/download/[% entry._id %]/[% entry.file.0.file_id %]/[% entry.file.0.file_name | uri %]">[% entry.file.0.file_name.match("(?i).pdf$") ? "PDF" : lf.main_page.links.file %]</a>
     [% END %]
   [% END %]

--- a/views/publication/record.tt
+++ b/views/publication/record.tt
@@ -164,7 +164,7 @@
       [%- IF fi %]
       <div class="col-xs-2 col-sm-3 col-sm-offset-1 text-sm-right">
 	     <div class="img-thumbnail img-thumbnail-fh">
-	        <a href="[% uri_base %]/download/[% _id %]/[% fi.file_id %]/[% fi.file_name | uri %]" title="[% fi.file_name %]" itemprop="thumbnailUrl" class="fulltext">
+	        <a [% IF fi.access_level == "open_access" OR (fi.access_level == "local" AND local_user) OR (fi.access_level = "closed" AND p.can_edit( _id, user_id = session.user_id, role = session.role )) %]href="[% uri_base %]/download/[% _id %]/[% fi.file_id %]/[% fi.file_name | uri %]"[% END %] title="[% fi.file_name %]" itemprop="thumbnailUrl" class="fulltext">
 	           <img src="[% uri_base %]/thumbnail/[% _id %]" itemprop="image" alt="[% h.loc("frontdoor.fulltext.view") %]" title="[% h.loc("frontdoor.fulltext.view") %]">
 	        </a>
 	     </div>

--- a/views/publication/record.tt
+++ b/views/publication/record.tt
@@ -74,7 +74,7 @@
               <div class="col-xs-2 text-muted">[% h.loc("frontdoor.download") %]</div>
               <div class="col-xs-9">
                   [% PROCESS publication/oa_lock.tt %]
-                  [% IF fi.access_level == "open_access" OR (fi.access_level == "local" AND local_user) %]
+                  [% IF fi.access_level == "open_access" OR (fi.access_level == "local" AND local_user) OR (fi.access_level = "closed" AND p.can_edit( _id, user_id = session.user_id, role = session.role )) %]
                   <a itemprop="url" href="[% uri_base %]/download/[% _id %]/[% fi.file_id %]/[% fi.file_name | uri %]" title="[% fi.file_name %]"[% IF fi.access_level != "open_access" %] target="_blank"[% END %]>
                     [% fi.title || fi.file_name | html %]
                   </a>

--- a/views/publication/tab_filedetails.tt
+++ b/views/publication/tab_filedetails.tt
@@ -38,7 +38,7 @@
   <div class="row[% UNLESS i==0 %] margin-top1[% END %]">
     <div class="col-md-3 text-muted">[% h.loc("frontdoor.tabs.file_details.name") %]</div>
     <div class="col-md-9">
-      [%- IF fi.access_level == "open_access" OR (fi.access_level == "local" AND local_user) %]
+      [%- IF fi.access_level == "open_access" OR (fi.access_level == "local" AND local_user) OR (fi.access_level = "closed" AND p.can_edit( _id, user_id = session.user_id, role = session.role )) %]
       <a itemprop="url" href="[% uri_base %]/download/[% _id %]/[% fi.file_id %]/[% fi.file_name | uri %]" title="[% fi.file_name %]">
         [% fi.file_name | html %]
       </a>


### PR DESCRIPTION
The permission of closed files was fixed in #423 (see #411), but the links to download the files haven't been displayed correctly. I also added the correct checks for permission there and now everything works as expected (link is rendered if and only if user has permission for file).