### PR TITLE
Open download links in new tab (in embedded view)

### DIFF
--- a/views/links.tt
+++ b/views/links.tt
@@ -2,7 +2,7 @@
 [% bag = entry.type == "research_data" ? "data" : "publication" %]
 <a href="[% uri_base %][% IF entry.status == "public" %]/[% bag %]/[% entry._id %][% ELSE %]/librecat/record/preview/[% entry._id %][% END %]" title="[% h.loc("main_page.links.view_details") %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>[% h.loc("main_page.links.details") %]</a>
   [% IF entry.type == "research_data" AND (entry.file || entry.related_material || entry.externalFiles == "1") %]
-  | <a href="[% uri_base %][% IF entry.status == "public" %]/[% bag %]/[% entry._id %][% ELSE %]/librecat/record/preview/[% entry._id %][% END %]" class="label label-primary">[% h.loc("main_page.links.files") %]</a>
+  | <a href="[% uri_base %][% IF entry.status == "public" %]/[% bag %]/[% entry._id %][% ELSE %]/librecat/record/preview/[% entry._id %][% END %]" class="label label-primary"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>[% h.loc("main_page.links.files") %]</a>
   [% ELSIF entry.type != "research_data" AND entry.file AND entry.file.size > 1 %]
     [% display_file = [] %]
     [% counter = 0 %]
@@ -10,13 +10,13 @@
     [% IF fi.open_access AND fi.relation != "hidden" %][% counter = counter + 1 %][% display_file.push(fi) %][% END %]
     [% END %]
     [% IF counter > 1 %]
-      | <a href="[% uri_base %][% IF entry.status == "public" %]/[% bag %]/[% entry._id %][% ELSE %]/librecat/record/preview/[% entry._id %][% END %]" class="label label-primary">[% h.loc("main_page.links.files") %]</a>
+      | <a href="[% uri_base %][% IF entry.status == "public" %]/[% bag %]/[% entry._id %][% ELSE %]/librecat/record/preview/[% entry._id %][% END %]" class="label label-primary"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>[% h.loc("main_page.links.files") %]</a>
     [% ELSIF counter == 1 %]
-      | <a href="[% uri_base %]/download/[% entry._id %]/[% display_file.0.file_id %]/[% display_file.0.file_name | uri %]">[% display_file.0.file_name.match("(?i).pdf$") ? "PDF" : lf.main_page.links.file %]</a>
+      | <a href="[% uri_base %]/download/[% entry._id %]/[% display_file.0.file_id %]/[% display_file.0.file_name | uri %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>[% display_file.0.file_name.match("(?i).pdf$") ? "PDF" : lf.main_page.links.file %]</a>
     [% END %]
   [% ELSIF entry.type != "research_data" AND entry.file AND entry.file.size == 1 %]
     [% IF entry.file.0.open_access %]
-    | <a href="[% uri_base %]/download/[% entry._id %]/[% entry.file.0.file_id %]/[% entry.file.0.file_name | uri %]">[% entry.file.0.file_name.match("(?i).pdf$") ? "PDF" : lf.main_page.links.file %]</a>
+    | <a href="[% uri_base %]/download/[% entry._id %]/[% entry.file.0.file_id %]/[% entry.file.0.file_name | uri %]"[% IF request.path_info.match("/embed") %] target="_blank"[% END %]>[% entry.file.0.file_name.match("(?i).pdf$") ? "PDF" : lf.main_page.links.file %]</a>
     [% END %]
   [% END %]
 


### PR DESCRIPTION
In the embedded view all external links (DOI,etc.) and the main record link are opened in a new tab at the moment. Only the download link is opened in a new tab. This is changed with this pull request.

Especially for files (like the download) this is quite user-friendly since the embedded iframe could be quite small. Furthermore, already for the record itsself, the user has to leave the context, so it is not worse to have it also for the file.