### PR TITLE
Show citethis link in mobile only if csl enabled

### DIFF
--- a/views/publication/record.tt
+++ b/views/publication/record.tt
@@ -192,7 +192,10 @@
           <li><a href="#relLinkRd" data-toggle="tab">[% h.loc("frontdoor.tabs.external_data.label") %]</a></li>
           [% END %]
 
+          [%- IF display_citation %]
           <li class="hidden-md hidden-lg hidden-sm"><a href="#citethis">[% h.loc("frontdoor.tabs.cite_this") %]</a></li>
+          [%- END %]
+          
           <li class="hidden-md hidden-lg hidden-sm"><a href="#export">[% h.loc("frontdoor.tabs.export_search") %]</a></li>
 
           [%- IF status == "public" %]


### PR DESCRIPTION
The corresponding citation div is only rendered if citation is available:

https://github.com/LibreCat/LibreCat/blob/317480b0fbc5d61d2ada791c4599133bac44feeb/views/publication/tab_details.tt#L218

Therefore, the link should also only rendered with the same condition.