### PR TITLE
Remove query parameters from marked link

### DIFF
--- a/views/filters.tt
+++ b/views/filters.tt
@@ -157,7 +157,7 @@
   [%- END %]
 
   <li>
-    <a href="[% request.uri_for("/marked", qp) %]" rel="nofollow" class="btn-link"><span class="label label-default total-marked">[% marked %]</span>[% h.loc("mark.marked_publication") %]</a>
+    <a href="[% request.uri_for("/marked") %]" rel="nofollow" class="btn-link"><span class="label label-default total-marked">[% marked %]</span>[% h.loc("mark.marked_publication") %]</a>
   </li>
 </ul>
 


### PR DESCRIPTION
Since the /marked page does not include any filters, it does not make any sense to carry the query parameters with the link. Instead it is quite confusing since I expect all marked entries there.