### PR TITLE
Fixing #472 project names in publication shouldt have any effect

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -229,9 +229,6 @@ publication:
       type: object
       properties:
         _id: *id
-        name:
-          type: string
-          description: "Project name"
       required: ["_id"]
 
     research_group: &research_group

--- a/lib/Template/Plugin/LibreCat/App/Helper.pm
+++ b/lib/Template/Plugin/LibreCat/App/Helper.pm
@@ -1,0 +1,26 @@
+package Template::Plugin::LibreCat::App::Helper;
+use base qw( Template::Plugin );
+use Template::Plugin;
+use LibreCat::App::Helper;
+
+sub new {
+    my $class   = shift;
+    my $context = shift;
+    $context->stash->set('h',h);
+    bless {}, $class;
+}
+
+=head1 NAME
+
+Template::Plugin::LibreCat::Helper - injects the helper functions.
+
+=head1 SYNOPSIS
+
+    # in your templates
+    [% USE LibreCat::App::Helper %]
+    [% h.get_department(id) %]
+
+=cut
+
+
+1;

--- a/t/Template/Plugin/LibreCat/App/Helper.t
+++ b/t/Template/Plugin/LibreCat/App/Helper.t
@@ -1,0 +1,16 @@
+use Catmandu::Sane;
+use LibreCat -load => {layer_paths => [qw(t/layer)]};
+use Test::More;
+use Test::Exception;
+use warnings FATAL => 'all';
+
+my $pkg;
+
+BEGIN {
+    $pkg = 'Template::Plugin::LibreCat::App::Helper';
+    use_ok $pkg;
+}
+
+require_ok $pkg;
+
+done_testing;

--- a/views/backend/generator/fields/project.tt
+++ b/views/backend/generator/fields/project.tt
@@ -10,7 +10,6 @@
     [% IF !project %]
     <div class="row innerrow multirow">
       <input type="hidden" name="project.0._id" id="pj_idautocomplete_0" value="" />
-      <input type="hidden" name="project.0.name" id="pj_nameautocomplete_0" value="" />
 
       <div class="form-group col-md-10 col-xs-11">
         <div class="input-group sticky{% IF fields.basic_fields.project.mandatory OR fields.supplementary_fields.project.mandatory %} mandatory{% END %}">
@@ -25,12 +24,11 @@
     [% FOREACH proj IN project %]
     <div class="row innerrow multirow">
       <input type="hidden" name="project.[% loop.index %]._id" id="pj_idautocomplete_[% loop.index %]" value="[% proj._id %]" />
-      <input type="hidden" name="project.[% loop.index %].name" id="pj_nameautocomplete_[% loop.index %]" value="[% proj.name %]" />
 
       <div class="form-group col-md-10 col-xs-11">
         <div class="input-group sticky{% IF fields.basic_fields.project.mandatory OR fields.supplementary_fields.project.mandatory %} mandatory{% END %}">
           <div class="input-group-addon hidden-lg hidden-md">[% h.loc("forms.${type}.field.project.label") %]</div>
-          <input type="text" onfocus="enable_autocomplete('pj',[% loop.index %]);" class="sticky form-control{% IF fields.basic_fields.project.mandatory OR fields.supplementary_fields.project.mandatory %}[% IF loop.first %] required[% END %]{% END %}" placeholder="[% h.loc("forms.${type}.field.project.placeholder") %]" id="pj_autocomplete_[% loop.index %]" value="[% proj.name | html %]"{% IF fields.basic_fields.project.readonly OR fields.supplementary_fields.project.readonly %} readonly="readonly" {% END %} disabled="disabled"/>
+          <input type="text" onfocus="enable_autocomplete('pj',[% loop.index %]);" class="sticky form-control{% IF fields.basic_fields.project.mandatory OR fields.supplementary_fields.project.mandatory %}[% IF loop.first %] required[% END %]{% END %}" placeholder="[% h.loc("forms.${type}.field.project.placeholder") %]" id="pj_autocomplete_[% loop.index %]" value="[% h.get_project(proj._id).name | html %]"{% IF fields.basic_fields.project.readonly OR fields.supplementary_fields.project.readonly %} readonly="readonly" {% END %} disabled="disabled"/>
           <div class="input-group-addon" onclick="add_field('project'[% IF lf.$type.field.project.placeholder %],'[% h.loc("forms.${type}.field.project.placeholder") %]'[% END %]);"><span class="fa fa-plus"></span></div>
           <div class="input-group-addon" onclick="remove_field(this);"><span class="fa fa-minus"></span></div>
         </div>

--- a/views/export/datacite.tt
+++ b/views/export/datacite.tt
@@ -1,4 +1,5 @@
 [%- USE XML::Strict -%]
+[%- USE LibreCat::App::Helper -%]
 <resource xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://datacite.org/schema/kernel-4" xsi:schemaLocation="http://datacite.org/schema/kernel-4 http://schema.datacite.org/meta/kernel-4.1/metadata.xsd">
   <identifier identifierType="DOI">[% doi | xml_strict %]</identifier>
   <creators>
@@ -77,11 +78,12 @@
   [%- IF project %]
   <fundingReferences>
   [%- FOREACH p IN project %]
+    [% project = h.get_project(p._id) %]
     <fundingReference>
-      [%- IF p.funder %]<funderName>[% p.funder.0 | xml_strict %]</funderName>[% END %]
-      [%- IF p.funder_id %]<funderIdentifier funderIdentifierType="Crossref Funder ID">[% p.funder_id | xml_strict %]</funderIdentifier>[% END %]
-      [%- IF p.grant_number %]<awardNumber>[% p.grant_number | xml_strict %]</awardNumber>[% END %]
-      <awardTitle>[% p.name | xml_strict %]</awardTitle>
+      [%- IF project.funder %]<funderName>[% project.funder.0 | xml_strict %]</funderName>[% END %]
+      [%- IF project.funder_id %]<funderIdentifier funderIdentifierType="Crossref Funder ID">[% project.funder_id | xml_strict %]</funderIdentifier>[% END %]
+      [%- IF project.grant_number %]<awardNumber>[% project.grant_number | xml_strict %]</awardNumber>[% END %]
+      <awardTitle>[% project.name | xml_strict %]</awardTitle>
     </fundingReference>
   [%- END %]
   </fundingReferences>

--- a/views/export/mods.tt
+++ b/views/export/mods.tt
@@ -9,6 +9,7 @@
       xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
 [%- END %]
 [%- USE XML::Strict -%]
+[%- USE LibreCat::App::Helper -%]
 
 <genre
 [%- SWITCH type -%]
@@ -127,7 +128,7 @@
 
 [%- FOREACH pr IN project %]
 <name type="corporate">
-  <namePart>[% pr.name | xml_strict %]</namePart>
+  <namePart>[% h.get_project(pr._id).name | xml_strict %]</namePart>
   <role><roleTerm type="text">project</roleTerm></role>
 </name>
 [%- END %]

--- a/views/publication/tab_details.tt
+++ b/views/publication/tab_details.tt
@@ -60,7 +60,7 @@
     <div class="col-lg-2 col-md-3 text-muted">[% h.loc("forms.${type}.field.project.label") %]</div>
     <div class="col-lg-10 col-md-9">
   [%- ELSE -%]<br />[% END %]
-  <a href="[% uri_base %]/project/[% proj._id %]">[% proj.name | html %]</a>
+  <a href="[% uri_base %]/project/[% proj._id %]">[% h.get_project(proj._id).name | html %]</a>
   [%- IF loop.last %]</div></div>[% END -%]
 [%- END -%]
 


### PR DESCRIPTION
Projects in publication are only referenced by their id. In webpages/exports these ids are matched against the project database to fetch the current name. Exciting project names in the publications will have no effect anymore, they can be safely deleted.