### PR TITLE
Fixes #506 abstracts without selected language

### DIFF
--- a/lib/Catmandu/Fix/clean_preselects.pm
+++ b/lib/Catmandu/Fix/clean_preselects.pm
@@ -18,6 +18,7 @@ sub fix {
         my @new_abstract;
 
         for my $ab (@{$pub->{abstract}}) {
+            $ab->{lang} = "eng" unless $ab->{lang};
             push @new_abstract, $ab if ($ab->{lang} && $ab->{text});
         }
 

--- a/views/backend/generator/fields/abstract.tt
+++ b/views/backend/generator/fields/abstract.tt
@@ -15,10 +15,10 @@
         <div class="input-group sticky{% IF fields.basic_fields.abstract.mandatory OR fields.supplementary_fields.abstract.mandatory %} mandatory{% END %}">
           <div class="input-group-addon">[% h.loc("forms.${type}.field.abstract.label2") %]</div>
           <select name="abstract.0.lang" id="id_abstract_language_0" class="sticky form-control">
-          <option value="" selected="selected">--- [% h.loc("forms.button.select") %] ---</option>
           [% FOREACH lang IN language_preselect %]
-          <option value="[% lang %]">[% h.loc("forms.language.${lang}") %]</option>
+          <option value="[% lang %]"[% IF lang == "eng" %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
           [% END %]
+          <option value="other">- [% h.loc("forms.language.other") %] -</option>
           [% FOREACH lang IN language_list.sort %]
           <option value="[% lang %]">[% h.loc("forms.language.${lang}") %]</option>
           [% END %]
@@ -41,10 +41,10 @@
           <div class="input-group sticky{% IF fields.basic_fields.abstract.mandatory OR fields.supplementary_fields.abstract.mandatory %} mandatory{% END %}">
             <div class="input-group-addon">[% h.loc("forms.${type}.field.abstract.label2") %]</div>
             <select name="abstract.[% loop.index %].lang" id="id_abstract_language_[% loop.index %]" class="sticky form-control">
-            <option value="">--- [% h.loc("forms.button.select") %] ---</option>
             [% FOREACH lang IN language_preselect %]
             <option value="[% lang %]" [% IF ab.lang == lang %]selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
             [% END %]
+            <option value="other">- [% h.loc("forms.language.other") %] -</option>
             [% FOREACH lang IN language_list.sort %]
             <option value="[% lang %]" [% IF ab.lang == lang %]selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
             [% END %]
@@ -68,10 +68,10 @@
         <div class="input-group sticky{% IF fields.basic_fields.abstract.mandatory OR fields.supplementary_fields.abstract.mandatory %} mandatory{% END %}">
           <div class="input-group-addon">[% h.loc("forms.${type}.field.abstract.label2") %]</div>
           <select name="abstract.0.lang" id="id_abstract_language_0" class="sticky form-control">
-          <option value="" [% IF !language %]selected="selected" [% END %]>--- [% h.loc("forms.button.select") %] ---</option>
           [% FOREACH lang IN language_preselect %]
-          <option value="[% lang %]" [% IF abstract.0.lang == lang %]selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
+          <option value="[% lang %]" [% IF !abstract AND lang == "eng" OR abstract.0.lang == lang %]selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
           [% END %]
+          <option value="other">- [% h.loc("forms.language.other") %] -</option>
           [% FOREACH lang IN language_list.sort %]
           <option value="[% lang %]" [% IF abstract.0.lang == lang %]selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
           [% END %]

--- a/views/backend/generator/fields/language.tt
+++ b/views/backend/generator/fields/language.tt
@@ -15,10 +15,10 @@
         <div class="input-group sticky{% IF fields.basic_fields.language.mandatory OR fields.supplementary_fields.language.mandatory %} mandatory{% END %}">
           <div class="input-group-addon hidden-lg hidden-md">[% lf.$type.field.language.label_short || lf.$type.field.language.label %]</div>
           <select name="language.0.iso" class="sticky form-control{% IF fields.basic_fields.language.mandatory OR fields.supplementary_fields.language.mandatory %} required{% END %}" id="select_language_0">
-            <option value="" selected="selected">--- [% h.loc("forms.button.select") %] ---</option>
             [% FOREACH lang IN language_preselect %]
-            <option value="[% lang %]">[% h.loc("forms.language.${lang}") %]</option>
+            <option value="[% lang %]"[% IF lang == "eng" %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
             [% END %]
+            <option value="other">- [% h.loc("forms.language.other") %] -</option>
             [% FOREACH lang IN language_list.sort %]
             <option value="[% lang %]">[% h.loc("forms.language.${lang}") %]</option>
             [% END %]
@@ -35,10 +35,10 @@
           <div class="input-group sticky{% IF fields.basic_fields.language.mandatory OR fields.supplementary_fields.language.mandatory %} mandatory{% END %}">
             <div class="input-group-addon hidden-lg hidden-md">[% lf.$type.field.language.label_short || lf.$type.field.language.label %]</div>
             <select name="language.[% loop.index %].iso" class="sticky form-control{% IF fields.basic_fields.language.mandatory OR fields.supplementary_fields.language.mandatory %}[% IF loop.first %] required[% END %]{% END %}" id="select_language_[% loop.index %]">
-              <option value="">--- [% h.loc("forms.button.select") %] ---</option>
               [% FOREACH lang IN language_preselect %]
               <option value="[% lang %]"[% IF lang == lan.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
               [% END %]
+              <option value="other">- [% h.loc("forms.language.other") %] -</option>
               [% FOREACH lang IN language_list.sort %]
               <option value="[% lang %]"[% IF lang == lan.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
               [% END %]
@@ -56,10 +56,10 @@
         <div class="input-group sticky{% IF fields.basic_fields.language.mandatory OR fields.supplementary_fields.language.mandatory %} mandatory{% END %}">
           <div class="input-group-addon hidden-lg hidden-md">[% lf.$type.field.language.label_short || lf.$type.field.language.label %]</div>
           <select name="language.0.iso" class="sticky form-control{% IF fields.basic_fields.language.mandatory OR fields.supplementary_fields.language.mandatory %} required{% END %}" id="select_language_0">
-            <option value="" [% IF !language %]selected="selected" [% END %]>--- [% h.loc("forms.button.select") %] ---</option>
             [% FOREACH lang IN language_preselect %]
-            <option value="[% lang %]"[% IF lang == language.0.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
+            <option value="[% lang %]"[% IF !language AND lang == "eng" OR lang == language.0.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
             [% END %]
+            <option value="other">- [% h.loc("forms.language.other") %] -</option>
             [% FOREACH lang IN language_list.sort %]
             <option value="[% lang %]"[% IF lang == language.0.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
             [% END %]

--- a/views/backend/generator/fields/publication_status_language.tt
+++ b/views/backend/generator/fields/publication_status_language.tt
@@ -36,10 +36,10 @@
                 <span class="hidden-lg hidden-md">[% h.loc("forms.${type}.field.publication_status_language.language.label_short") %]</span>
               </div>
               <select name="language.0.iso" class="sticky form-control{% IF fields.basic_fields.publication_status_language.language.mandatory OR fields.supplementary_fields.publication_status_language.language.mandatory %} required{% END %}" id="select_language_0">
-                <option value="" selected="selected">--- [% h.loc("forms.button.select") %] ---</option>
                 [% FOREACH lang IN language_preselect %]
-                <option value="[% lang %]">[% h.loc("forms.language.${lang}") %]</option>
+                <option value="[% lang %]"[% IF lang == "eng" %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
                 [% END %]
+                <option value="other">- [% h.loc("forms.language.other") %] -</option>
                 [% FOREACH lang IN language_list.sort %]
                 <option value="[% lang %]">[% h.loc("forms.language.${lang}") %]</option>
                 [% END %]
@@ -59,10 +59,10 @@
                   <span class="hidden-lg hidden-md">[% h.loc("forms.${type}.field.publication_status_language.language.label_short") %]</span>
                 </div>
                 <select name="language.[% loop.index %].iso" class="sticky form-control{% IF fields.basic_fields.publication_status_language.mandatory OR fields.supplementary_fields.publication_status_language.mandatory %}[% IF loop.first %] required[% END %]{% END %}" id="select_language_[% loop.index %]">
-                  <option value="">--- [% h.loc("forms.button.select") %] ---</option>
                   [% FOREACH lang IN language_preselect %]
                   <option value="[% lang %]"[% IF lang == lan.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
                   [% END %]
+                  <option value="other">- [% h.loc("forms.language.other") %] -</option>
                   [% FOREACH lang IN language_list.sort %]
                   <option value="[% lang %]"[% IF lang == lan.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
                   [% END %]
@@ -83,10 +83,10 @@
                 <span class="hidden-lg hidden-md">[% h.loc("forms.${type}.field.publication_status_language.language.label_short") %]</span>
               </div>
               <select name="language.0.iso" class="sticky form-control{% IF fields.basic_fields.publication_status_language.language.mandatory OR fields.supplementary_fields.publication_status_language.language.mandatory %} required{% END %}" id="select_language_0">
-                <option value="" [% IF !language %]selected="selected" [% END %]>--- [% h.loc("forms.button.select") %] ---</option>
                 [% FOREACH lang IN language_preselect %]
-                <option value="[% lang %]"[% IF lang == language.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
+                <option value="[% lang %]"[% IF !language AND lang == "eng" OR lang == language.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
                 [% END %]
+                <option value="other">- [% h.loc("forms.language.other") %] -</option>
                 [% FOREACH lang IN language_list.sort %]
                 <option value="[% lang %]"[% IF lang == language.iso %] selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
                 [% END %]


### PR DESCRIPTION
Abstracts without language selection were not stored.

After this PR: if no language is selected, the fix will assign English to the abstract. In a new rec, English will be preselected for the abstract, but removed if no abstract text is added.

The general language field of a record will also have English preselected, so that any record will have a language.