### PR TITLE
Allow role change directly on backend page

### DIFF
--- a/views/home.tt
+++ b/views/home.tt
@@ -24,7 +24,7 @@
                     [%- END %]
                 </div>
                 <div class="col-md-6 col-sm-5 col-xs-12">
-                    <h3 class="margin-top0">[% UNLESS !thisPerson %][% IF thisPerson.idm_title %]<span itemprop="honorificPrefix">[% thisPerson.idm_title %]</span>[% END %] <span itemprop="name">[% thisPerson.first_name %] [% thisPerson.last_name %]</span>[% IF backend %] ([% h.loc("header.role.${session.role}") %])[% END %][% ELSE %][% h.loc("person_profile.id_not_found") %][% END %]</h3>
+                    <h3 class="margin-top0">[% UNLESS !thisPerson %]Dashboard: [% IF thisPerson.idm_title %]<span itemprop="honorificPrefix">[% thisPerson.idm_title %]</span>[% END %] <span itemprop="name">[% thisPerson.first_name %] [% thisPerson.last_name %]</span>[% IF backend %] ([% h.loc("header.role.${session.role}") %])[% END %][% ELSE %][% h.loc("person_profile.id_not_found") %][% END %]</h3>
 
                     [%- IF backend AND (thisPerson.super_admin OR thisPerson.reviewer OR thisPerson.project_reviewer OR thisPerson.data_manager OR thisPerson.delegate ) %]
                         ([% h.loc("header.role_change") %]

--- a/views/home.tt
+++ b/views/home.tt
@@ -24,7 +24,7 @@
                     [%- END %]
                 </div>
                 <div class="col-md-6 col-sm-5 col-xs-12">
-                    <h3 class="margin-top0">[% UNLESS !thisPerson %]Dashboard: [% IF thisPerson.idm_title %]<span itemprop="honorificPrefix">[% thisPerson.idm_title %]</span>[% END %] <span itemprop="name">[% thisPerson.first_name %] [% thisPerson.last_name %]</span>[% IF backend %] ([% h.loc("header.role.${session.role}") %])[% END %][% ELSE %][% h.loc("person_profile.id_not_found") %][% END %]</h3>
+                    <h3 class="margin-top0">[% UNLESS !thisPerson %][% IF backend %]Dashboard: [% END %][% IF thisPerson.idm_title %]<span itemprop="honorificPrefix">[% thisPerson.idm_title %]</span>[% END %] <span itemprop="name">[% thisPerson.first_name %] [% thisPerson.last_name %]</span>[% IF backend %] ([% h.loc("header.role.${session.role}") %])[% END %][% ELSE %][% h.loc("person_profile.id_not_found") %][% END %]</h3>
 
                     [%- IF backend AND (thisPerson.super_admin OR thisPerson.reviewer OR thisPerson.project_reviewer OR thisPerson.data_manager OR thisPerson.delegate ) %]
                         ([% h.loc("header.role_change") %]

--- a/views/home.tt
+++ b/views/home.tt
@@ -46,6 +46,7 @@
                         [%- IF thisPerson.super_admin AND session.role != "super_admin" %]
                         | <a href="[% uri_base %]/librecat/change_role/admin">[% h.loc("header.role.super_admin") %]</a>
                         [%- END %]
+                        )
                     [%- END %]
                     
                     [% INCLUDE person_profile.tt %]

--- a/views/home.tt
+++ b/views/home.tt
@@ -25,6 +25,29 @@
                 </div>
                 <div class="col-md-6 col-sm-5 col-xs-12">
                     <h3 class="margin-top0">[% UNLESS !thisPerson %][% IF thisPerson.idm_title %]<span itemprop="honorificPrefix">[% thisPerson.idm_title %]</span>[% END %] <span itemprop="name">[% thisPerson.first_name %] [% thisPerson.last_name %]</span>[% IF backend %] ([% h.loc("header.role.${session.role}") %])[% END %][% ELSE %][% h.loc("person_profile.id_not_found") %][% END %]</h3>
+
+                    [%- IF backend AND (thisPerson.super_admin OR thisPerson.reviewer OR thisPerson.project_reviewer OR thisPerson.data_manager OR thisPerson.delegate ) %]
+                        ([% h.loc("header.role_change") %]
+                        [%- IF session.role != "user" %]
+                        <a href="[% uri_base %]/librecat/change_role/user">[% h.loc("header.role.user") %]</a>
+                        [%- END %]
+                        [%- IF thisPerson.delegate AND session.role != "delegate" %]
+                        | <a href="[% uri_base %]/librecat/change_role/delegate">[% h.loc("header.role.delegate") %]</a>
+                        [%- END %]
+                        [%- IF thisPerson.reviewer AND session.role != "reviewer" %]
+                        | <a href="[% uri_base %]/librecat/change_role/reviewer">[% h.loc("header.role.reviewer") %]</a>
+                        [%- END %]
+                        [%- IF thisPerson.project_reviewer AND session.role != "project_reviewer" %]
+                        | <a href="[% uri_base %]/librecat/change_role/project_reviewer">[% lf.header.role.project_reviewer %]</a>
+                        [%- END %]
+                        [%- IF thisPerson.data_manager AND session.role != "data_manager" %]
+                        | <a href="[% uri_base %]/librecat/change_role/data_manager">[% h.loc("header.role.data_manager") %]</a>
+                        [%- END %]
+                        [%- IF thisPerson.super_admin AND session.role != "super_admin" %]
+                        | <a href="[% uri_base %]/librecat/change_role/admin">[% h.loc("header.role.super_admin") %]</a>
+                        [%- END %]
+                    [%- END %]
+                    
                     [% INCLUDE person_profile.tt %]
                 </div>
                 [% IF backend %]


### PR DESCRIPTION
In addition to the role change in the settings menu, it is directly possible on the backend page (as discussed in #415 ). The result looks as follows:

![image](https://user-images.githubusercontent.com/6943048/41496447-ed5d34bc-7140-11e8-8386-f7c19fb789fc.png)
