### PR TITLE
Use https where possible

### DIFF
--- a/config/lists.yml
+++ b/config/lists.yml
@@ -9,29 +9,29 @@ cc_licenses:
 author_id:
   inspire:
     label: INSPIRE ID
-    url: "http://inspirehep.net/record/"
+    url: "https://inspirehep.net/record/"
   arxiv:
     label: ArXiv ID
-    url: "http://arxiv.org/a/"
+    url: "https://arxiv.org/a/"
   orcid:
     label: ORCID
-    url: "http://orcid.org/"
+    url: "https://orcid.org/"
     icon: " <sup><img src='/images/icon_orcid.png' /></sup>"
   googleScholar:
     label: Google Scholar Profile
-    url: "http://scholar.google.de/citations?user="
+    url: "https://scholar.google.de/citations?user="
   github:
     label: GitHub
-    url: "http://github.com/"
+    url: "https://github.com/"
   researcherId:
     label: Researcher ID
-    url: "http://www.researcherid.com/rid/"
+    url: "https://www.researcherid.com/rid/"
   authorClaim:
     label: Author Claim
     url: "http://authorclaim.org/profile/"
   scopusId:
     label: Scopus Author ID
-    url: "http://www.scopus.com/authid/detail.url?authorId="
+    url: "https://www.scopus.com/authid/detail.url?authorId="
   alias:
     label: Alias
     url: "/person/"

--- a/config/lists.yml
+++ b/config/lists.yml
@@ -9,7 +9,7 @@ cc_licenses:
 author_id:
   inspire:
     label: INSPIRE ID
-    url: "https://inspirehep.net/record/"
+    url: "https://inspirehep.net/author/profile/"
   arxiv:
     label: ArXiv ID
     url: "https://arxiv.org/a/"
@@ -19,7 +19,7 @@ author_id:
     icon: " <sup><img src='/images/icon_orcid.png' /></sup>"
   googleScholar:
     label: Google Scholar Profile
-    url: "https://scholar.google.de/citations?user="
+    url: "https://scholar.google.com/citations?user="
   github:
     label: GitHub
     url: "https://github.com/"


### PR DESCRIPTION
Since the browser will force users to https in the next months (or at least warn them), I updated the external services to the urls with https where available (only authorclaim sadly does not support ssl so far).

Additionally, I've updated two links to the corresponding primary urls to prevent unnecessary redirects.