### PR TITLE
Fixes missing facets

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -9,6 +9,7 @@ views:
       facets:
         - - template: facets/popular_science
             facet: popular_science
+            min: 1
           - template: facets/extern
             facet: extern
             min: 1
@@ -36,8 +37,10 @@ views:
             facet: year
         - - template: facets/popular_science
             facet: popular_science
+            min: 1
           - template: facets/extern
             facet: extern
+            min: 1
           - template: facets/open_access
             facet: open_access
             min: 1


### PR DESCRIPTION
For all facets with only one value (open_access=1, popular_science=1) "min: 1" needs to be set, otherwise the facet will not be displayed.

This is in relation to #429 

Both frontend and backend facets have been corrected in this PR.