### PR TITLE
use content-disposition

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/file.pm
+++ b/lib/LibreCat/App/Catalogue/Route/file.pm
@@ -49,7 +49,9 @@ sub _send_it {
     my $store = $opts{access} ? h->get_access_store() : h->get_file_store();
     my $format = h->config->{files}->{download_file_name};
     $format = is_string($format) ? $format : "%o";
-    my $name = str_format($format, i => $key, o => $filename, f => $fileid, e => h->file_extension($filename));
+    my $extension = h->file_extension($filename);
+    $extension =~ s/^\.//o;
+    my $name = str_format($format, i => $key, o => $filename, f => $fileid, e => $extension);
 
     return undef unless $store->index->exists($key);
 

--- a/t/LibreCat/App/Catalogue/Route/file.t
+++ b/t/LibreCat/App/Catalogue/Route/file.t
@@ -1,8 +1,12 @@
 use Catmandu::Sane;
+use Path::Tiny;
+use lib path(__FILE__)->parent->parent->child('lib')->stringify;
 use LibreCat -load => {layer_paths => [qw(t/layer)]};
-use Test::More;
 use Test::Exception;
-use warnings FATAL => 'all';
+use Test::More import => ['!pass'];
+use Test::WWW::Mechanize::PSGI;
+use LibreCat::App::Helper;
+use IO::File;
 
 my $pkg;
 
@@ -13,7 +17,82 @@ BEGIN {
 
 require_ok $pkg;
 
-is LibreCat::App::Catalogue::Route::file::str_format( "%o", i => 1, f => "DS.0", e => "pdf", o => "test.pdf" ), "test.pdf";
-is LibreCat::App::Catalogue::Route::file::str_format( "%i-%f.%e", i => 1, f => "DS.0", e => "pdf", o => "test.pdf" ), "1-DS.0.pdf";
+is LibreCat::App::Catalogue::Route::file::str_format( "%o", i => 1, f => "DS.0", e => "pdf", o => "test.pdf" ), "test.pdf", "str_format %o";
+is LibreCat::App::Catalogue::Route::file::str_format( "%i-%f.%e", i => 1, f => "DS.0", e => "pdf", o => "test.pdf" ), "1-DS.0.pdf", "str_format %i-%f.%e";
+
+my $app = eval {require 'bin/app.pl';};
+my $mech = Test::WWW::Mechanize::PSGI->new( app => $app );
+$mech->max_redirect(0);
+
+#login
+{
+    $mech->get_ok("/login");
+    my $res = $mech->submit_form(
+        form_number => 1,
+        fields      => {user => "einstein", pass => "einstein"},
+    );
+    is($res->code, 302, "/login redirects, as expected");
+}
+
+my $helper = LibreCat::App::Helper::Helpers->new();
+my $file_store = $helper->get_file_store();
+my $pubs = LibreCat->instance->model("publication");
+
+my $record_id = $pubs->generate_id;
+my $file_id = "AC";
+my $file_name = "publication.pdf";
+my $source_file = "t/data3/000/000/001/$file_name";
+my $file_size = -s $source_file;
+
+#upload file
+{
+
+    $file_store->index->add({ _id => $record_id });
+    my $files = $file_store->index->files( $record_id );
+    my $ok = $files->upload( IO::File->new($source_file), $file_name );
+
+    my $r = {
+        _id => $record_id,
+        title => $file_name,
+        status => "published",
+        type => "book",
+        user_id => 1234,
+        creator => {
+            id => 1234,
+            login => "einstein"
+        },
+        author => [{
+            id => 1234,
+            first_name => "Albert",
+            last_name => "Einstein",
+            full_name => "Albert Einstein"
+        }],
+        file => [
+            {
+                file_id => $file_id,
+                file_name => $file_name,
+                file_size => int( $file_size ),
+                content_type => "application/pdf",
+                creator => 1234,
+                access_level => "open_access",
+                open_access => 1,
+                relation => "main_file",
+                date_created => "2018-08-06T11:46:00Z",
+                date_updated => "2018-08-06T11:46:00Z",
+                title => $file_name
+            }
+        ]
+    };
+    $pubs->bag->add($r);
+    $pubs->search_bag->add($r);
+    $pubs->bag->commit();
+    $pubs->search_bag->commit;
+}
+
+#get file
+{
+    $mech->get_ok("/download/$record_id/$file_id/$file_name");
+    is( $mech->content_type, "application/pdf", "content type set correctly" );
+}
 
 done_testing;

--- a/t/LibreCat/App/Catalogue/Route/file.t
+++ b/t/LibreCat/App/Catalogue/Route/file.t
@@ -13,4 +13,7 @@ BEGIN {
 
 require_ok $pkg;
 
+is LibreCat::App::Catalogue::Route::file::str_format( "%o", i => 1, f => "DS.0", e => "pdf", o => "test.pdf" ), "test.pdf";
+is LibreCat::App::Catalogue::Route::file::str_format( "%i-%f.%e", i => 1, f => "DS.0", e => "pdf", o => "test.pdf" ), "1-DS.0.pdf";
+
 done_testing;

--- a/t/LibreCat/App/Catalogue/Route/file.t
+++ b/t/LibreCat/App/Catalogue/Route/file.t
@@ -44,7 +44,8 @@ my $file_name = "publication.pdf";
 my $source_file = "t/data3/000/000/001/$file_name";
 my $file_size = -s $source_file;
 
-ok $pubs->delete_all, "delete all existing publications at the beginning";
+$pubs->delete_all;
+$file_store->index->delete_all;
 
 #upload file
 {
@@ -97,6 +98,7 @@ ok $pubs->delete_all, "delete all existing publications at the beginning";
     is( $mech->content_type, "application/pdf", "content type set correctly" );
 }
 
-ok $pubs->delete_all, "delete all existing publications at the end";
+$pubs->delete_all;
+$file_store->index->delete_all;
 
 done_testing;

--- a/t/LibreCat/App/Catalogue/Route/file.t
+++ b/t/LibreCat/App/Catalogue/Route/file.t
@@ -44,6 +44,8 @@ my $file_name = "publication.pdf";
 my $source_file = "t/data3/000/000/001/$file_name";
 my $file_size = -s $source_file;
 
+ok $pubs->delete_all, "delete all existing publications at the beginning";
+
 #upload file
 {
 
@@ -94,5 +96,7 @@ my $file_size = -s $source_file;
     $mech->get_ok("/download/$record_id/$file_id/$file_name");
     is( $mech->content_type, "application/pdf", "content type set correctly" );
 }
+
+ok $pubs->delete_all, "delete all existing publications at the end";
 
 done_testing;


### PR DESCRIPTION
* use id-file.extension as suggested filename
* don't use the internal filename anymore
TODO: deprecate old route that uses the file_name

Issues:
* Chrome sometimes ignores the header content-disposition. Try uploading a file with extension ".txt", and download it.