### PR TITLE
Consistent formatting of project and department in record details

### DIFF
--- a/views/publication/tab_details.tt
+++ b/views/publication/tab_details.tt
@@ -60,7 +60,7 @@
     <div class="col-lg-2 col-md-3 text-muted">[% h.loc("forms.${type}.field.project.label") %]</div>
     <div class="col-lg-10 col-md-9">
   [%- ELSE -%]<br />[% END %]
-  <a href="[% uri_base %]/project/[% proj._id %]">[% proj.name | html %]</a>
+  <a href="[% uri_base %]/project/[% proj._id %]" class="long">[% proj.name | html %]</a>
   [%- IF loop.last %]</div></div>[% END -%]
 [%- END -%]
 


### PR DESCRIPTION
Added the css class long to the project link as it is handled for the departments to have a consistent behaviour for comparable details