### PR TITLE
Allow external_id field to be placed in related_material section of the form.

### DIFF
--- a/config/forms.yml
+++ b/config/forms.yml
@@ -113,6 +113,7 @@ field_order:
     - related_material.record
     - related_material.rd
     - main_file_link
+    - external_id
     - related_material.link
 
 # file dropzone fields that may be changed/edited

--- a/views/backend/generator/fields/external_id.tt
+++ b/views/backend/generator/fields/external_id.tt
@@ -4,14 +4,14 @@
     <label for="select_external_id">
       [% h.loc("forms.${type}.field.external_id.label") %]
     </label>
-    {% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory %}<span class="starMandatory"></span>&nbsp;{% END %}
+    {% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %}<span class="starMandatory"></span>&nbsp;{% END %}
   </div>
   <div class="col-md-10" id="extId">
-    {% IF fields.basic_fields.external_id.multiple OR fields.supplementary_fields.external_id.multiple %}
+    {% IF fields.basic_fields.external_id.multiple OR fields.supplementary_fields.external_id.multiple OR fields.related_material.external_id.multiple %}
     [% IF !external_id %]
     <div class="row innerrow multirow">
       <div class="form-group col-md-10 col-xs-11">
-        <div class="input-group sticky{% IF fields.basic_fields.publication_identifier.mandatory %} mandatory{% END %}">
+        <div class="input-group sticky{% IF fields.basic_fields.publication_identifier.mandatory OR fields.supplementary_fields.publication_identifier.mandatory OR fields.related_material.publication_identifier.mandatory %} mandatory{% END %}">
           <div class="input-group-addon hidden-lg hidden-md">[% lf.$type.field.external_id.label_short || lf.$type.field.external_id.label %]</div>
           <span class="input-group-btn">
             <select class="btn btn-default" name="external_id.0.type" id="select_external_id">
@@ -21,8 +21,8 @@
               [% END %]
             </select>
           </span>
-          <input type="text" value="" placeholder="[% h.loc("forms.${type}.field.external_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory %} required{% END %}" name="external_id.0.value" id="external_id_0"{% IF fields.basic_fields.external_id.readonly OR fields.supplementary_fields.external_id.readonly %} readonly="readonly"{% END %} />
-          <div class="input-group-addon" onclick="add_field('extId');"><span class="fa fa-plus"{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory %} data-mandatory="yes"{% END %}></span></div>
+          <input type="text" value="" placeholder="[% h.loc("forms.${type}.field.external_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %} required{% END %}" name="external_id.0.value" id="external_id_0"{% IF fields.basic_fields.external_id.readonly OR fields.supplementary_fields.external_id.readonly OR fields.related_material.external_id.readonly %} readonly="readonly"{% END %} />
+          <div class="input-group-addon" onclick="add_field('extId');"><span class="fa fa-plus"{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %} data-mandatory="yes"{% END %}></span></div>
           <div class="input-group-addon" onclick="remove_field(this);"><span class="fa fa-minus"></span></div>
         </div>
       </div>
@@ -35,7 +35,7 @@
         [% FOREACH identifier IN external_id.$ext_id %]
         <div class="row innerrow multirow">
           <div class="form-group col-md-10 col-xs-11">
-            <div class="input-group sticky{% IF fields.basic_fields.external_id.mandatory %} mandatory{% END %}">
+            <div class="input-group sticky{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %} mandatory{% END %}">
               <div class="input-group-addon hidden-lg hidden-md">[% lf.$type.field.external_id.label_short || lf.$type.field.external_id.label %]</div>
               <span class="input-group-btn">
                 <select class="btn btn-default" name="external_id.[% index %].type">
@@ -45,8 +45,8 @@
                   [% END %]
                 </select>
               </span>
-              <input type="text" value="[% identifier %]" placeholder="[% h.loc("forms.${type}.field.external_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory %}[% IF localindex == 0 %] required[% END %]{% END %}" name="external_id.[% index %].value" id="external_id_[% index %]"{% IF fields.basic_fields.external_id.readonly OR fields.supplementary_fields.external_id.readonly %} readonyl="readonly"{% END %} />
-              <div class="input-group-addon" onclick="add_field('extId');"><span class="fa fa-plus"{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory %} data-mandatory="yes"{% END %}></span></div>
+              <input type="text" value="[% identifier %]" placeholder="[% h.loc("forms.${type}.field.external_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %}[% IF localindex == 0 %] required[% END %]{% END %}" name="external_id.[% index %].value" id="external_id_[% index %]"{% IF fields.basic_fields.external_id.readonly OR fields.supplementary_fields.external_id.readonly OR fields.related_material.external_id.readonly %} readonyl="readonly"{% END %} />
+              <div class="input-group-addon" onclick="add_field('extId');"><span class="fa fa-plus"{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %} data-mandatory="yes"{% END %}></span></div>
               <div class="input-group-addon" onclick="remove_field(this);"><span class="fa fa-minus"></span></div>
             </div>
           </div>
@@ -56,7 +56,7 @@
         [% ELSE %]
         <div class="row innerrow multirow">
           <div class="form-group col-md-10 col-xs-11">
-            <div class="input-group sticky{% IF fields.basic_fields.external_id.mandatory %} mandatory{% END %}">
+            <div class="input-group sticky{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %} mandatory{% END %}">
               <div class="input-group-addon hidden-lg hidden-md">[% lf.$type.field.external_id.label_short || lf.$type.field.external_id.label %]</div>
               <span class="input-group-btn">
                 <select class="btn btn-default" name="external_id.[% localindex %].type">
@@ -66,8 +66,8 @@
                   [% END %]
                 </select>
               </span>
-              <input type="text" value="[% external_id.$ext_id %]" placeholder="[% h.loc("forms.${type}.field.external_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory %}[% IF localindex == "0" %] required[% END %]{% END %}" name="external_id.[% localindex %].value" id="external_id_[% localindex %]" {% IF fields.basic_fields.external_id.readonly OR fields.supplementary_fields.external_id.readonly %} readonly="readonly"{% END %}/>
-              <div class="input-group-addon" onclick="add_field('extId');"><span class="fa fa-plus"{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory %} data-mandatory="yes"{% END %}></span></div>
+              <input type="text" value="[% external_id.$ext_id %]" placeholder="[% h.loc("forms.${type}.field.external_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %}[% IF localindex == "0" %] required[% END %]{% END %}" name="external_id.[% localindex %].value" id="external_id_[% localindex %]" {% IF fields.basic_fields.external_id.readonly OR fields.supplementary_fields.external_id.readonly OR fields.related_material.external_id.readonly %} readonly="readonly"{% END %}/>
+              <div class="input-group-addon" onclick="add_field('extId');"><span class="fa fa-plus"{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %} data-mandatory="yes"{% END %}></span></div>
               <div class="input-group-addon" onclick="remove_field(this);"><span class="fa fa-minus"></span></div>
             </div>
           </div>
@@ -78,7 +78,7 @@
     {% ELSE %}
     <div class="row innerrow">
       <div class="form-group col-md-10 col-xs-11">
-        <div class="input-group sticky{% IF fields.basic_fields.publication_identifier.mandatory %} mandatory{% END %}">
+        <div class="input-group sticky{% IF fields.basic_fields.publication_identifier.mandatory OR fields.supplementary_fields.publication_identifier.mandatory OR fields.related_material.publication_identifier.mandatory %} mandatory{% END %}">
           <div class="input-group-addon hidden-lg hidden-md">[% lf.$type.field.external_id.label_short || lf.$type.field.external_id.label %]</div>
           <span class="input-group-btn">
             <select class="btn btn-default" name="external_id.0.type">
@@ -88,7 +88,7 @@
               [% END %]
             </select>
           </span>
-          <input type="text" value="" placeholder="[% h.loc("forms.${type}.field.external_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory %} required{% END %}" name="external_id.0.value" id="external_id_0"{% IF fields.basic_fields.external_id.readonly OR fields.supplementary_fields.external_id.readonly %} readonly="readonly"{% END %} />
+          <input type="text" value="" placeholder="[% h.loc("forms.${type}.field.external_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.external_id.mandatory OR fields.supplementary_fields.external_id.mandatory OR fields.related_material.external_id.mandatory %} required{% END %}" name="external_id.0.value" id="external_id_0"{% IF fields.basic_fields.external_id.readonly OR fields.supplementary_fields.external_id.readonly OR fields.related_material.external_id.readonly %} readonly="readonly"{% END %} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
The forms are meant to be flexible in placing fields in the different parts of the form. But so far this is only implemented for basic_fields and supplementary_fields. Fields can be moved between these two parts easily, but not the other two.

This PR solves #530 for the field external_id.

To place the field in the related_material section of a form, edit the forms.yml and move the definition of the field from ```publication_types.{type}.fields.supplementary_fields``` to ```publication_types.{type}.fields.related_material```. Then run ```bin/librecat generate forms```.

If more fields need to be moved from basic_fields or supplementary_fields to one of the other two sections, look at the diff in this PR and recreate what I have done for external_id.