### PR TITLE
Fixes page numbers being lost when saving

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -518,6 +518,8 @@ publication:
         - type: string
         - type: integer
       description: "Page number"
+    page_range_number:
+      type: object
     email:
       type: string
       description: "Email address (of dissertation student)"


### PR DESCRIPTION
When saving a record, neither the page(range), nor the article number were being saved.

Reason: the validator runs before the fix moves the values from the field called "page_range_number" to the fields "page" and "article_number". And the validator didn't know a field called "page_range_number", so it deleted the field.