### PR TITLE
Remove html encodig from abstract on publication frontdoor

### DIFF
--- a/views/publication/tab_details.tt
+++ b/views/publication/tab_details.tt
@@ -89,7 +89,7 @@
     <div class="col-lg-2 col-md-3 text-muted">[% h.loc("forms.${type}.field.abstract.label") %]</div>
     <div class="col-lg-10 col-md-9 cmark abstract" itemprop="about">
     [%- FOREACH ab IN abstract %][% UNLESS loop.first %]<br /><hr>[% END %]
-      [% ab.text | html %]
+      [% ab.text %]
     [%- END %]
     </div>
   </div>


### PR DESCRIPTION
The abstract field should support markdown and html formatting.

With the ```| html``` encoding, however, html tags are being printed verbatim and not interpreted by the browser for formatting.

