### PR TITLE
Redirect to /librecat from similar_search if no search params

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/search.pm
+++ b/lib/LibreCat/App/Catalogue/Route/search.pm
@@ -48,6 +48,7 @@ Performs search for similar titles, admin only
     get '/admin/similar_search' => sub {
 
         my $p = h->extract_params();
+        redirect '/librecat' unless keys %$p;
 
         # TODO filter out deleted recs
         my $hits = searcher->native_search(


### PR DESCRIPTION
Redirect to /librecat from /similar_search if there are no search params. Otherwise the user will land on a similar_search page with no hits (e.g. after deleting the search terms).