### PR TITLE
pr/fix_validator_for_projects

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -1020,8 +1020,12 @@ project:
       type: string
       pattern: '\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d([+-][0-2]\d:[0-5]\d|Z)'
       description: "The project last modification date"
-    affiliation:
-      type: string
+    department:
+      type: array
+      items:
+        type: object
+        properties:
+          _id: *id
       description: "Project's affiliation"
     owner:
       type: array


### PR DESCRIPTION
Validator/schema entry for "department" in a project entry was called "affiliation" instead of "department", which is why no department could be saved for a project.