### PR TITLE
Add a space (was: "Allow html in file description on frontdoor")

### DIFF
--- a/views/publication/tab_filedetails.tt
+++ b/views/publication/tab_filedetails.tt
@@ -68,7 +68,7 @@
   <div class="row">
     <div class="col-md-3 text-muted">[% h.loc("frontdoor.tabs.file_details.description") %]</div>
     <div class="col-md-9">
-      [% fi.description %]
+      [% fi.description | html %]
     </div>
   </div>
   [%- END %]

--- a/views/publication/tab_filedetails.tt
+++ b/views/publication/tab_filedetails.tt
@@ -6,11 +6,11 @@
       <strong>[% h.loc("frontdoor.license_heading") %]</strong><br />
       <div class="alert alert-green">
       [%- IF data_reuse_license %]
-        [% h.loc("forms.${type}.field.license.data_reuse_license.label") %] :
+        [% h.loc("forms.${type}.field.license.data_reuse_license.label") %]:
         [%- SWITCH data_reuse_license %]
-          [%- CASE 'PDDL' %]<a href="http://opendatacommons.org/licenses/pddl/" target="_blank">[% h.loc("forms.${type}.field.license.data_reuse_license.pddl.name") %]</a>
-	      [%- CASE 'ODC-By' %]<a href="http://opendatacommons.org/licenses/by/" target="_blank">[% h.loc("forms.${type}.field.license.data_reuse_license.odcby.name") %]</a>
-	      [%- CASE 'ODbL' %]<a href="http://opendatacommons.org/licenses/odbl/" target="_blank">[% h.loc("forms.${type}.field.license.data_reuse_license.odbl.name") %]</a>
+          [%- CASE 'PDDL' %] <a href="http://opendatacommons.org/licenses/pddl/" target="_blank">[% h.loc("forms.${type}.field.license.data_reuse_license.pddl.name") %]</a>
+	      [%- CASE 'ODC-By' %] <a href="http://opendatacommons.org/licenses/by/" target="_blank">[% h.loc("forms.${type}.field.license.data_reuse_license.odcby.name") %]</a>
+	      [%- CASE 'ODbL' %] <a href="http://opendatacommons.org/licenses/odbl/" target="_blank">[% h.loc("forms.${type}.field.license.data_reuse_license.odbl.name") %]</a>
         [%- END %]
       [%- END %]
       [%- IF cc_license %]
@@ -68,7 +68,7 @@
   <div class="row">
     <div class="col-md-3 text-muted">[% h.loc("frontdoor.tabs.file_details.description") %]</div>
     <div class="col-md-9">
-      [% fi.description | html %]
+      [% fi.description %]
     </div>
   </div>
   [%- END %]


### PR DESCRIPTION
Remove template html filter for file description on frontdoor to allow for html tags in description.

And fix incorrectly placed space in data re-use license.