### PR TITLE
Error in cql mapping for publications

### DIFF
--- a/config/store.yml
+++ b/config/store.yml
@@ -480,7 +480,7 @@ search:
                 'all': true
                 '=': true
                 '<>': true
-                'exact': {field: ['author.full_name.exact', 'author.id.exact', 'editor.full_name.exact', 'editor.id.exact', 'translator.full_name.exact', 'translator.id.exact']}
+                'exact': {field: ['author.full_name.exact', 'author.id', 'editor.full_name.exact', 'editor.id', 'translator.full_name.exact', 'translator.id']}
               field: ['author.full_name', 'author.id', 'editor.full_name', 'editor.id', 'translator.full_name', 'translator.id']
             supervisor:
               op:


### PR DESCRIPTION
 "person exact" searches the fields "id.exact" (author.id.exact etc.), which don't exist in index mapping. This leads to no results when searching for "person exact 1234" for example.

There is no need for a separate author.id.exact field, so I just changed the cql mapping accordingly.