### PR TITLE
Remove deleted recs from similar search

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/search.pm
+++ b/lib/LibreCat/App/Catalogue/Route/search.pm
@@ -63,6 +63,9 @@ Performs search for similar titles, admin only
                                 }
                             }
                         },
+                        "must_not" => {
+                            "term" => { "status" => "deleted" }
+                        },
                         "should" => {
                             "match_phrase" => {
                                 "title" =>


### PR DESCRIPTION
Add a search filter to similar_search to exclude deleted recs from search results. (This search does not use the regular search via the bag, because it sets percentages on hit accuracy and word spacing.)