### PR TITLE
Correct label on frontdoor for more authors

### DIFF
--- a/views/publication/javascriptShowHide.tt
+++ b/views/publication/javascriptShowHide.tt
@@ -6,10 +6,10 @@ function ShowAuthors (){
   var str = "" ;
   [% FOREACH au IN author %]
     [% IF loop.count > 12 %]
-    str +=  " ; [% IF au.id %]<a itemprop='author' href='[% uri_base %]/person/[% au.id %]'>[% au.full_name %]</a><sup class='muted'>Local</sup>[% ELSE %]<span itemprop='author'>[% au.full_name %]</span>[% END %]" ;
+    str +=  " ; [% IF au.id %]<a itemprop='author' href='[% uri_base %]/person/[% au.id %]'>[% au.full_name %]</a><sup class='muted'><strong>[% h.loc('frontdoor.local_brand') %]</strong></sup>[% ELSE %]<span itemprop='author'>[% au.full_name %]</span>[% END %][% IF au.orcid %] <a href='https://orcid.org/[% au.orcid %]'><sup><img src='[% uri_base %]/images/icon_orcid.png' /></sup></a>[% END %]" ;
     [% END %]
   [% END %]
-  str += "<br><a href='#details' onclick='ReduceAuthors();'><span class='fa fa-minus fw'></span>Less</a>" ;
+  str += "<br><a href='#details' onclick='ReduceAuthors();return false;'><span class='fa fa-minus fw'></span>Less</a>" ;
   document.getElementById('showAut').innerHTML= str ;
 }
 

--- a/views/publication/tab_details.tt
+++ b/views/publication/tab_details.tt
@@ -25,7 +25,7 @@
       [%- IF person.orcid %] <a href="http://orcid.org/[% person.orcid %]"><sup><img src="[% uri_base %]/images/icon_orcid.png" /></sup></a>[% END %]
       [%- IF loop.count > 11 %]
         <span id="showAut">
-          <br><a href="#details" onclick="ShowAuthors();"><span class="fa fa-plus fw"></span>[% h.loc("frontdoor.show_all") %]</a>
+          <br><a href="#details" onclick="ShowAuthors();return false;"><span class="fa fa-plus fw"></span>[% h.loc("frontdoor.show_all") %]</a>
         </span>
         </div>
       </div>


### PR DESCRIPTION
Show correct label for local authors on frontdoor after clicking the '+more' link. It was a hard coded label called 'local' instead of whatever is set in the config files.

Also prevent page from jumping up when clicking the "+more" link and show orcid icon in that area.