### PR TITLE
move the 'add_urn' functionality from a Catmandu::Fix to a LibreCat::…

### DIFF
--- a/fixes/update_publication.fix
+++ b/fixes/update_publication.fix
@@ -7,7 +7,6 @@ form2schema(publication_identifier)
 form2schema(external_id)
 page_range_number()
 clean_preselects()
-add_urn()
 person()
 volume_sort()
 

--- a/lib/LibreCat/Hook/add_urn.pm
+++ b/lib/LibreCat/Hook/add_urn.pm
@@ -1,15 +1,15 @@
-package Catmandu::Fix::add_urn;
+package LibreCat::Hook::add_urn;
 
 =pod
 
 =head1 NAME
 
-Catmandu::Fix::add_urn - create a urn field from the input data
+LibreCat::Hook::add_urn - create a urn field from the input data
 
 =cut
 
 use Catmandu::Sane;
-use LibreCat::App::Helper;
+use LibreCat qw(config);
 use Carp;
 use Moo;
 
@@ -32,7 +32,7 @@ sub fix {
 
         if ($oa and $pub->{type} ne 'research_data') {
             $pub->{urn}
-                = $self->_generate_urn(h->config->{urn_prefix}, $pub->{_id});
+                = $self->_generate_urn(config->{urn_prefix}, $pub->{_id});
         }
     }
 

--- a/t/LibreCat/Hook/add_urn.t
+++ b/t/LibreCat/Hook/add_urn.t
@@ -7,7 +7,7 @@ use LibreCat -load => {layer_paths => [qw(t/layer)]};
 my $pkg;
 
 BEGIN {
-    $pkg = 'Catmandu::Fix::add_urn';
+    $pkg = 'LibreCat::Hook::add_urn';
     use_ok $pkg;
 }
 require_ok $pkg;


### PR DESCRIPTION
…Hook.

This is only used for registration at the German National Library, and as such
should be configurable.