### PR TITLE
Fix generated department links

### DIFF
--- a/lib/LibreCat/Cmd/generate.pm
+++ b/lib/LibreCat/Cmd/generate.pm
@@ -260,7 +260,7 @@ sub _generate_departments {
     open(my $fh, '>:encoding(UTF-8)', "$output_path/nodes.tt")
         || die "failed to write nodes.tt: $!";
 
-    $self->_template_printer($HASH, "publication", $fh);
+    $self->_template_printer($HASH, "record", $fh);
 
     close($fh);
 


### PR DESCRIPTION
Currently the generated department links on the department tab still use /publication. (see http://demo.librecat.org/department) This PR changes the ```bin/librecat generate department``` command to use /record in those links.

This PR requires a ```bin/librecat generate department```

The incorrect department links also lead to incorreclty generated embed links for departments. So, this PR is related  to PR #596 