### PR TITLE
Fixes export on author page

### DIFF
--- a/t/www/my_publication_list.t
+++ b/t/www/my_publication_list.t
@@ -32,7 +32,7 @@ note("my publication list");
     $mech->follow_link_ok({url_regex => qr(/person/1234$), n => 1},
         'my publication list');
 
-    $mech->content_contains("/marked?person=1234", "found right page");
+    $mech->content_contains("/marked", "found right page");
 }
 
 done_testing;

--- a/views/filters.tt
+++ b/views/filters.tt
@@ -11,7 +11,6 @@
 
 [%- IF request.path_info.match("person") AND bag != 'person' %]
 <div class="margin-bottom1">
-  [%- qp.person = id %]
   <a href="[% request.uri_for("/marked", qp) %]" rel="nofollow"><span class="label label-default total-marked">[% marked %]</span>[% h.loc("mark.marked_publication") %]</a>
 </div>
 [%- END -%]
@@ -124,6 +123,7 @@
     <div class="facettecollapse">
     <ul id="export_facet" class="collapse">
       [%- tmp = {}; tmp.import(qp); export_path = backend == 1 ? 'librecat/export' : 'export' %]
+      [%- IF request.path_info.match("person") %][%- tmp.cql = !tmp.cql ? [] : tmp.cql %][%- tmp.cql.push("person=$id") %][%- END %]
       <li><a href="#modal" data-toggle="modal" rel="nofollow"><span class="fa fa-fw fa-share-square-o"></span>[% h.loc("facets.exports.rtf") %]</a></li>
       <li><a href="[% tmp.fmt='bibtex'; request.uri_for(export_path, tmp) %]" rel="nofollow"><span class="fa fa-fw fa-share-square-o"></span>[% h.loc("facets.exports.bibtex") %]</a></li>
       <li><a href="[% tmp.fmt='ris'; request.uri_for(export_path, tmp) %]" rel="nofollow"><span class="fa fa-fw fa-share-square-o"></span>[% h.loc("facets.exports.ris") %]</a></li>
@@ -171,6 +171,7 @@
       </div>
       <div class="modal-body">
         [%- tmp = {}; tmp.import(qp); tmp.bag = 'publication'; tmp.fmt = 'rtf'; tmp.links = '1' %]
+        [%- IF request.path_info.match("person") %][%- tmp.cql = !tmp.cql ? [] : tmp.cql %][%- tmp.cql.push("person=$id") %][%- END %]
 	     <p><span class="fa fa-chevron-right"></span><a href="[% request.uri_for(export_path, tmp) %]" class="rtfmodal" rel="nofollow">[% h.loc("facets.export_withlinks") %]</a></p>
          [%-  tmp.delete('links') %]
 	     <p><span class="fa fa-chevron-right"></span><a href="[% request.uri_for(export_path, tmp) %]" class="rtfmodal" rel="nofollow">[% h.loc("facets.export_withoutlinks") %]</a></p>


### PR DESCRIPTION
The export links were missing the cql=person=id parameter, causing ALL publications in the system to be exported instead of only the author's publications. (Instead there was a parameter "person=id" hanging around with no real use or meaning.)