### PR TITLE
uri_escape file_name with utf8 mark

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/file.pm
+++ b/lib/LibreCat/App/Catalogue/Route/file.pm
@@ -18,7 +18,7 @@ use LibreCat::App::Helper;
 use LibreCat::App::Catalogue::Controller::Permission;
 use DateTime;
 use Catmandu::Util qw(:is);
-use URI::Escape qw(uri_escape);
+use URI::Escape qw(uri_escape uri_escape_utf8);
 
 #str_format( "%f.%e", f => "DS.0", e => "txt" )
 sub str_format {
@@ -93,7 +93,7 @@ sub _send_it {
                     'Cache-Control' =>
                         'no-store, no-cache, must-revalidate, max-age=0',
                     'Pragma' => 'no-cache',
-                    'Content-Disposition' => qq(inline; filename="$name")
+                    'Content-Disposition' => "inline; filename*=UTF-8''".uri_escape_utf8($name)
                 );
 
          # Send the HTTP headers


### PR DESCRIPTION
HTTP headers only allow ascii characters, while we accept any file name.
The plack writer crashes with "wide characters in .." if we try to download
a file like that, returning an incomplete response.