### PR TITLE
add field alternative_id as hidden field when normal user

### DIFF
--- a/views/backend/generator/fields/alternative_id.tt
+++ b/views/backend/generator/fields/alternative_id.tt
@@ -46,4 +46,8 @@
     {% END %}
   </div>
 </div>
+[% ELSE %]
+  [% FOREACH altid IN alternative_id.list %]
+    <input type="hidden" value="[% altid | html %]" name="alternative_id.[% loop.index %]" id="id_alternative_id_[% loop.index %]">
+  [% END %]
 [% END %]


### PR DESCRIPTION
The field "alternative_id" is only added to the form when the user role is "super_admin".
Saving the record as a regular user therefore removes the alternative ids from the record.

For now, I added these fields as hidden fields to the form when you are a regular user.