### PR TITLE
Fix applicant field error in patent forms

### DIFF
--- a/lib/Catmandu/Fix/person.pm
+++ b/lib/Catmandu/Fix/person.pm
@@ -21,7 +21,7 @@ sub _build_helper {
 
 sub fix {
     my ($self, $data) = @_;
-    my @types = qw(author editor translator supervisor applicant);
+    my @types = qw(author editor translator supervisor);
 
     my $users = $self->helper->main_user;
 

--- a/views/backend/generator/fields/applicant.tt
+++ b/views/backend/generator/fields/applicant.tt
@@ -38,8 +38,7 @@
           <div class="input-group sticky{% IF fields.basic_fields.applicant.mandatory OR fields.supplementary_fields.applicant.mandatory %} mandatory{% END %}">
             <div class="input-group-addon hidden-lg hidden-md">[% h.loc("forms.${type}.field.applicant.label") %]</div>
             <input type="text" name="applicant.0" id="id_applicant_0" value="[% applicant.0 %]" class="sticky form-control{% IF fields.basic_fields.applicant.mandatory OR fields.supplementary_fields.applicant.mandatory %} required{% END %}" placeholder="[% h.loc("forms.${type}.field.applicant.placeholder") %]"{% IF fields.basic_fields.applicant.readonly OR fields.supplementary_fields.applicant.readonly %} readonly="readonly"{% END %} />
-            <div class="input-group-addon" onclick="add_field('applicant');"><span class="fa fa-plus"></span></div>
-            <div class="input-group-addon" onclick="remove_field(this);"><span class="fa fa-minus"></span></div>
+            <div class="input-group-addon"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Remove the applicant field from the person fix (this field does not have the correct format and produces an error when sent into the fix).

Also remove the +/- button from the applicant field if it is configured as not multiple.