### PR TITLE
Missing div in template

### DIFF
--- a/views/backend/generator/fields/alternative_id.tt
+++ b/views/backend/generator/fields/alternative_id.tt
@@ -16,8 +16,9 @@
           <input type="text" name="alternative_id.0" id="id_alternative_id_0" value="" placeholder="[% h.loc("forms.${type}.field.alternative_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.alternative_id.mandatory OR fields.supplementary_fields.alternative_id.mandatory %} required{% END %}"{% IF fields.basic_fields.alternative_id.readonly OR fields.supplementary_fields.alternative_id.readonly %} readonly="readonly"{% END %} />
           <div class="input-group-addon" onclick="add_field('alternative_id');"><span class="fa fa-plus"></span></div>
           <div class="input-group-addon" onclick="remove_field(this);"><span class="fa fa-minus"></span></div>
+        </div><br />
+        <em>[% h.loc("forms.${type}.field.alternative_id.desc") %]</em>
       </div>
-      <em>[% h.loc("forms.${type}.field.alternative_id.desc") %]</em>
     </div>
     [% ELSE %]
     [% FOREACH altid IN alternative_id %]
@@ -28,9 +29,9 @@
           <input type="text" name="alternative_id.[% loop.index %]" id="id_alternative_id_[% loop.index %]" value="[% altid %]" placeholder="[% h.loc("forms.${type}.field.alternative_id.placeholder") %]" class="form-control{% IF fields.basic_fields.alternative_id.mandatory OR fields.supplementary_fields.alternative_id.mandatory %} required{% END %}"{% IF fields.basic_fields.alternative_title.readonly OR fields.supplementary_fields.alternative_title.readonly %} readonly="readonly"{% END %}>
           <div class="input-group-addon" onclick="add_field('alternative_id');"><span class="fa fa-plus"></span></div>
           <div class="input-group-addon" onclick="remove_field(this);"><span class="fa fa-minus"></span></div>
-        </div>
+        </div><br />
+        <em>[% h.loc("forms.${type}.field.alternative_id.desc") %]</em>
       </div>
-      <em>[% h.loc("forms.${type}.field.alternative_id.desc") %]</em>
     </div>
     [% END %]
     [% END %]
@@ -41,10 +42,10 @@
           <div class="hidden-lg hidden-md input-group-addon">[% h.loc("forms.${type}.field.alternative_id.label") %]</div>
           <input type="text" name="alternative_id.0" id="id_alternative_id_0" value="[% alternative_id.0 %]" placeholder="[% h.loc("forms.${type}.field.alternative_id.placeholder") %]" class="sticky form-control{% IF fields.basic_fields.alternative_id.mandatory OR fields.supplementary_fields.alternative_id.mandatory %} required{% END %}"{% IF fields.basic_fields.alternative_id.readonly OR fields.supplementary_fields.alternative_id.readonly %} readonly="readonly"{% END %}>
           <div class="input-group-addon"></div>
-        </div>
+        </div><br />
+        <em>[% h.loc("forms.${type}.field.alternative_id.desc") %]</em>
       </div>
     </div>
-    <em>[% h.loc("forms.${type}.field.alternative_id.desc") %]</em>
     {% END %}
   </div>
 </div>

--- a/views/backend/generator/master.tt
+++ b/views/backend/generator/master.tt
@@ -5,7 +5,7 @@
 
 [% INCLUDE header.tt %]
 
-<!-- BEGIN backend/generator/master_expert.tt -->
+<!-- BEGIN backend/generator/master.tt -->
 <!-- changes here must be generated -->
 <div class="col-md-11 col-md-offset-1">
 
@@ -115,5 +115,5 @@
 {% INCLUDE fields/jquery_tab1.tt %}
 </script>
 
-<!-- END backend/generator/master_expert.tt -->
+<!-- END backend/generator/master.tt -->
 [% INCLUDE footer.tt %]


### PR DESCRIPTION
Fix in html of the forms: There was one closing div missing in the alternative_id template (line 19) which caused the footer to move upwards into the form and into the buttons.

In addition I have fixed the placement of the description for this field (placed below the input) and I have corrected an explanatory comment in the master.tt correctly identifying the used template.