### PR TITLE
Error in user validation (via account form)

### DIFF
--- a/fixes/update_user.fix
+++ b/fixes/update_user.fix
@@ -1,4 +1,5 @@
 # fix user data at update
+vacuum()
 
 unless exists(account_status)
     add_field(account_status,inactive)


### PR DESCRIPTION
Add the ```vacuum()``` fix to the beginning of the ```update_user.fix``` to keep ```password: undef``` from upsetting the validator.

**This error only occurs when the password field in the user account form is not mandatory and when no password has been set.**

The data hash passed to ```user->add($p)``` will contain ```password: undef```, but the validator expects password min-length: 1. So ```user->add($p)``` returns 0 and the record is never stored.

In turn, the vaccum should not interfere with existing passwords in the db. Nor with newly set passwords, because then the field is not empty and vacuum will not touch it.