### PR TITLE
move Module::Install to phase test

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,10 +15,10 @@ on 'test' => sub {
     requires 'Test::Pod';
     requires 'Test::TCP';
     requires 'Test::WWW::Mechanize::Dancer';
+    requires 'Module::Install', '1.16';
 };
 
 requires 'Business::ISBN', 0;
-requires 'Module::Install', '1.16';
 
 # Catmandu
 requires 'Catmandu', '>=1.0606';
@@ -104,7 +104,6 @@ requires 'Log::Any::Adapter';
 requires 'Log::Any::Adapter::Log4perl';
 requires 'Log::Log4perl';
 requires 'MIME::Types','==1.38';
-requires 'Module::Install';
 requires 'Moo', '>= 2.003004';
 requires 'Net::LDAP';
 requires 'Net::LDAPS';


### PR DESCRIPTION
Several reasons for this pull request:

* Module::Install is mentioned twice in cpanfile
* Module::Install is only needed during the installation of the perl modules
* I guess it was only added to make the installation of Gearman::XS work? That only uses it during install. If you mention it in the main list (i.e. not within a phase), then there is no order implied, so carton can decide to install Gearman::XS first (which happened to me several times, and that's why it failed), and then Module::Install. This actually preinstalls it before processing the main list, and deletes it afterwards.