### PR TITLE
fixing 'mark all' for person's profile page

### DIFF
--- a/views/mark_all_js.tt
+++ b/views/mark_all_js.tt
@@ -3,6 +3,9 @@
 var path = '[% request.uri_for(request.path_info) %]',
 searchParams = [% h.extract_params.json %];
 [%- IF !backend %]
+if (typeof searchParams.cql == 'undefined') {
+    searchParams.cql = [];
+}
 if (searchParams.cql) {
     searchParams.cql.push('person=[% id %]');
 }


### PR DESCRIPTION
In a person's profile page, when clicking 'mark all', it is literally marking all publications in the system (to a limit of 1000). This is because there is no 'cql' param in 'searchParams'. The edit above adds the cql param if missing.