### PR TITLE
Bugfix: ORCID iD not deleted when unlinking author

### DIFF
--- a/public/javascripts/librecat.js
+++ b/public/javascripts/librecat.js
@@ -419,6 +419,7 @@ function link_person(element){
             $('#' + type + 'Authorized' + lineId).attr('src',librecat.uri_base + '/images/authorized_no.png');
             $('#' + type + 'Authorized' + lineId).attr('alt','Not Authorized');
             $('#' + type + 'id_' + lineId).val("");
+            $('#' + type + 'orcid_' + lineId).val("");
             $('#' + type + 'first_name_' + lineId + ', #' + type + 'last_name_' + lineId).removeAttr("readonly");
             $('#' + type + 'first_name_' + lineId).val(orig_first_name);
             $('#' + type + 'orig_first_name_' + lineId).val("");


### PR DESCRIPTION
In the edit forms: when a linked author (editor etc.) with an ORCID iD is unlinked, the ORCID iD is not deleted from the hidden input field and remains in the record.

This PR fixes that.