### PR TITLE
Add missing (counter)relation "cites"

### DIFF
--- a/config/lists.yml
+++ b/config/lists.yml
@@ -269,6 +269,9 @@ relations_record:
     relation: "is_cited_by"
     opposite: "cites"
   -
+    relation: "cites"
+    opposite: "is_cited_by"
+  -
     relation: "other"
     opposite: "other"
 


### PR DESCRIPTION
In the lists.yml add the missing (counter)relation cites to is_cited_by. For each pair of relations there are two entries needed.

This missing relation also caused an error in the Material.pm when saving a record with relation is_cited_by.