### PR TITLE
order of fixes is important, citation fix should be applied at the end

### DIFF
--- a/lib/LibreCat/Model/Publication.pm
+++ b/lib/LibreCat/Model/Publication.pm
@@ -14,11 +14,14 @@ sub BUILD {
     my ($self) = @_;
     $self->prepend_before_add(
         [
-
             # TODO this is very dirty and executes even if validation fails
             file             => '_store_file',
             related_material => '_store_related_material',
+        ]
+    );
 
+    $self->append_before_add(
+        [
             # TODO move to config
             citation => Catmandu::Fix::add_citation->new,
         ]


### PR DESCRIPTION
This fixes a citation bug, where not all fields were processed in the citation engine. It turns out that the order of fixes is important here. The citation fix needs the other fixes to be processed in first place.