### PR TITLE
Fixes access error for delegates

### DIFF
--- a/lib/LibreCat/Access.pm
+++ b/lib/LibreCat/Access.pm
@@ -118,7 +118,7 @@ sub all_user_ids {
         $values = [ $values ] unless is_array_ref $values;
 
         for my $identify (@$values) {
-            push @ids , $identify->{id};
+            push @ids , $identify->{id} if $identify->{id};
         }
     }
 


### PR DESCRIPTION
In some LibreCat installations delegates get the error 'uninitialized value $iid in string eq' after login.

This error was reported to us. I was not able to reproduce it on our systems. But looking at the code, the error is plausible (and it is rather strange that it could not be reproduced).

The error is thrown in line 96 of the Access.pm.   
In this part of the code the list of author/editor/translator/creator ids of the publication is checked against the list of user ids the current user has delegation rights for.   
This line uses an array of ids from the publication, provided by ```$self->all_user_ids($pub);```. But in many publications there are authors/editors/translators that do not have ids. In those cases line 96 uses an uninitialized value in a string equation.

To prevent this, I changed the ```all_user_ids``` sub to only add an element to the array if it is defined.   
This is reported to fix the error.

The only thing that puzzles me is why this error does not happen in all installations or why it can't be reproduced.