### PR TITLE
Add language attribute to HTML tag configurable via locale

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -4,6 +4,7 @@ _prefix:
 
 appname: "LibreCat &ndash; Publikationslisten Manager"
 appname_short: "LibreCat"
+language_code: "de"
 general:
   plural: "en"
   where: "in"

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -4,6 +4,7 @@ _prefix:
 
 appname: "LibreCat &ndash; Publication List Manager"
 appname_short: "LibreCat"
+language_code: "en"
 general:
   plural: "s"
   where: "in"

--- a/views/header.tt
+++ b/views/header.tt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="h.loc('language_code')">
 [% lang = h.locale() -%]
 [% lf = h.config.locale.$lang -%]
 [% path_info = request.path_info -%]


### PR DESCRIPTION
Sets the according html attribute depending on the chosen language locale. This enables e.g. auto hyphenation and word wrap for long abstracts and descriptions.