### PR TITLE
space added to the end of characters in hexmap

### DIFF
--- a/lib/Catmandu/Exporter/RTF.pm
+++ b/lib/Catmandu/Exporter/RTF.pm
@@ -138,7 +138,7 @@ sub _add_citation {
     while ($cite =~ /\\\'(\d{3,4})/) {
         my $hexv = $1;
         if ($HEXMAP->{$hexv}) {
-            $cite =~ s/\\\'$hexv/$HEXMAP->{$hexv} /g;
+            $cite =~ s/\\\'$hexv/$HEXMAP->{$hexv}/g;
         }
         else {
             $cite =~ s/\\\'$hexv//g;
@@ -156,7 +156,7 @@ sub _add_citation {
         while ($title =~ /\\\'(\d{3,4})/) {    # why while??
             my $hexv = $1;
             if ($HEXMAP->{$hexv}) {
-                $title =~ s/\\\'$hexv/$HEXMAP->{$hexv} /g;
+                $title =~ s/\\\'$hexv/$HEXMAP->{$hexv}/g;
             }
             else {
                 $title =~ s/\\\'$hexv//g;


### PR DESCRIPTION
example of citation with space after Š character:

`Hilbe C, S imsa S , Chatterjee K, Nowak M. 2018. Evolution of cooperation in stochastic games. Nature. 559(7713).`

after fix:

`Hilbe C, Simsa S, Chatterjee K, Nowak M. 2018. Evolution of cooperation in stochastic games. Nature. 559(7713).`

Is this my change generating the expected or was there some reason for the space?