### PR TITLE
Fix missing labels (xx_secondary, xx_solo) on frontdoor 

### DIFF
--- a/views/publication/tab_details.tt
+++ b/views/publication/tab_details.tt
@@ -11,10 +11,12 @@
 [%- END %]
 
 [%- FOREACH item IN ['translator', 'author', 'supervisor', 'editor'] %]
-    [% FOREACH person IN $item %]
-      [% IF loop.first %]
+    [%- FOREACH person IN $item %]
+      [%- IF loop.first %]
       <div class="row">
-        <div class="col-lg-2 col-md-3 text-muted">[% h.loc("forms.${type}.field.${item}.label") || h.loc("forms.${type}.field.${item}_secondary.label") || h.loc("forms.${type}.field.${item}_solo.label") %]</div>
+        [%- au_secondary = item _ "_secondary" %]
+        [%- IF h.config.locale.en.forms.$type.field.$item.label %][% loc_item =  "forms." _ type _ ".field." _ item _ ".label" %][% ELSIF h.config.locale.en.forms.$type.field.$au_secondary.label %][% loc_item = "forms." _ type _ ".field." _ item _ "_secondary.label" %][% ELSE %][% loc_item = "forms." _ type _ ".field."_ item _ "_solo.label" %][% END -%]
+        <div class="col-lg-2 col-md-3 text-muted">[% h.loc("${loc_item}") %]</div>
         <div class="col-lg-10 col-md-9">
       [%- ELSE %];[% END %]
       [%- IF person.id %]
@@ -37,7 +39,8 @@
 [%- FOREACH ed IN corporate_editor %]
   [%- IF loop.first %]
   <div class="row">
-    <div class="col-lg-2 col-md-3 text-muted">[% h.loc("forms.${type}.field.corporate_editor.label") || h.loc("forms.${type}.field.corporate_editor_solo.label") %]</div>
+    [%- loc_item = h.config.locale.en.forms.$type.field.corporate_editor.label ? "forms." _ type _ ".field.corporate_editor.label" : "forms." _ type _ ".field.corporate_editor_solo.label" -%]
+    <div class="col-lg-2 col-md-3 text-muted">[% h.loc("${loc_item}") %]</div>
     <div class="col-lg-10 col-md-9">
   [%- ELSE -%];[% END %]
   [% ed | html %]


### PR DESCRIPTION
These missing labels are due to the way h.loc works.

We need a check if the "editor.label" or the "editor_solo.label" exists and should be displayed. But, h.loc always returns something, even if the label is not present in the locale.yml. So a ```[% IF h.loc("forms.book.field.editor_solo.label") %]``` will always return true.

The solution is kind of a bad hack, but it works.