### PR TITLE
Fix a server error on person page (after a search)

### DIFF
--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -194,7 +194,8 @@ sub is_marked {
 sub all_marked {
     my ($self) = @_;
     my $p = $self->extract_params();
-    push @{$p->{q}}, "status=public";
+    push @{$p->{cql}}, $p->{q} if $p->{q};
+    push @{$p->{cql}}, "status=public";
 
     my $hits       = librecat->searcher->search('publication', $p);
     my $marked     = Dancer::session 'marked';


### PR DESCRIPTION
The search on ```/person/[id]``` pages throws an internal server error. The search results (```hits.tt```) on that page call ```h.all_marked```, where parameter q is a string but an array is expected.

Solution: push q to cql first and use that parameter for further processing.