### PR TITLE
evt preventDefault; escape =; quote cql field value

### DIFF
--- a/views/filters.tt
+++ b/views/filters.tt
@@ -199,7 +199,7 @@ $('#id_button_embed_[% tabmodus %][% menu %]').click(function() {
     var no_params = embed_link.match(/\/person\/(\d+)$/);
     var yes_params = embed_link.match(/\/person\/(\d+)\?.*/);
     if(no_params){
-      embed_link = embed_link.replace(/\/person\/\d+/, "/embed?q=person=" + no_params[1]);
+      embed_link = embed_link.replace(/\/person\/\d+/, "/embed?q=person%3" + no_params[1]);
     }
     else if(yes_params){
       embed_link = embed_link.replace(/\/person.*/, "/embed?");
@@ -226,7 +226,8 @@ $('#id_button_embed_[% tabmodus %][% menu %]').click(function() {
     $('#id_linktext').val(emb_link);
 });
 
-$('a.facet_[% tabmodus %]').click(function() {
+$('a.facet_[% tabmodus %]').click(function(evt) {
+  evt.preventDefault();
   var par_key = $(this).data('key');
   if(!searchParams[par_key]){
     searchParams[par_key] = [];
@@ -235,7 +236,7 @@ $('a.facet_[% tabmodus %]').click(function() {
     searchParams[par_key].push($(this).data('value'));
   }
   else if(par_key == "cql"){
-    searchParams[par_key].push($(this).data('param') + "=" + $(this).data('value'));
+    searchParams[par_key].push($(this).data('param') + "=\"" + $(this).data('value') + "\"");
     delete searchParams.start;
     delete searchParams.fmt;
   }


### PR DESCRIPTION
* "=" in a query should be escaped
* when change the url in a javascript callback, first stop the original event from happening. Without this, the "href" of the link (i.e "#") is still shown in the url bar, after which the new url is loaded.
* cql field value should be quoted. I have a facet on content types, so a forward slash is part of the value. A query like

```
content_type=image/tiff
```

fails in the background, because a forward slash has a special meaning

Other escaping rules?