### PR TITLE
Pr/fix typo in supervisor field

### DIFF
--- a/views/backend/generator/fields/supervisor.tt
+++ b/views/backend/generator/fields/supervisor.tt
@@ -85,7 +85,7 @@
             <div class="input-group-addon">
               <span id="supervisor_link_person_[% loop.index %]" onclick="link_person(this);" data-type="supervisor_">
               <label class="radio-inline">
-                <input type="radio" name="supversior_idm.[% loop.index %]" id="supervisor_idm_extern_[% loop.index %]"[% IF !name.id %] checked="checked"[% END %]> [% h.loc("forms.${type}.field.supervisor.idm_extern") %]
+                <input type="radio" name="supervisor_idm.[% loop.index %]" id="supervisor_idm_extern_[% loop.index %]"[% IF !name.id %] checked="checked"[% END %]> [% h.loc("forms.${type}.field.supervisor.idm_extern") %]
               </label>
               <label class="radio-inline">
                 <input type="radio" name="supervisor_idm.[% loop.index %]" id="supervisor_idm_intern_[% loop.index %]"[% IF name.id %] checked="checked"[% END %]> <img id="supervisor_Authorized[% loop.index %]" [% IF name.id %]src="[% uri_base %]/images/authorized_yes.png"[% ELSE %]src="[% uri_base %]/images/authorized_no.png"[% END %] [% IF name.id %]alt="Authorized"[% ELSE %]alt="Not Authorized"[% END %] data-toggle="tooltip" data-html="true" data-placement="bottom" title="[% h.loc("forms.${type}.field.supervisor.tooltip") %]" />
@@ -136,7 +136,7 @@
                 <input type="radio" name="supervisor_idm.0" id="supervisor_idm_extern_0"[% IF !supervisor.0.id %] checked="checked"[% END %]> [% h.loc("forms.${type}.field.supervisor.idm_extern") %]
               </label>
               <label class="radio-inline">
-                <input type="radio" name="supversior_idm.0" id="supervisor_idm_intern_0"[% IF supervisor.0.id %] checked="checked"[% END %]> <img id="supervisor_Authorized0" [% IF supervisor.0.id %]src="[% uri_base %]/images/authorized_yes.png"[% ELSE %]src="[% uri_base %]/images/authorized_no.png"[% END %] [% IF supervisor.0.id %]alt="Authorized"[% ELSE %]alt="Not Authorized"[% END %] data-toggle="tooltip" data-html="true" data-placement="bottom" title="[% h.loc("forms.${type}.field.supervisor.tooltip") %]" />
+                <input type="radio" name="supervisor_idm.0" id="supervisor_idm_intern_0"[% IF supervisor.0.id %] checked="checked"[% END %]> <img id="supervisor_Authorized0" [% IF supervisor.0.id %]src="[% uri_base %]/images/authorized_yes.png"[% ELSE %]src="[% uri_base %]/images/authorized_no.png"[% END %] [% IF supervisor.0.id %]alt="Authorized"[% ELSE %]alt="Not Authorized"[% END %] data-toggle="tooltip" data-html="true" data-placement="bottom" title="[% h.loc("forms.${type}.field.supervisor.tooltip") %]" />
               </label>
               </span>
             </div>


### PR DESCRIPTION
Typo in some of the radio buttons (name) of the supervisor field. Leads to error with javascript function (link person).