### PR TITLE
put audit in separate package;no use more for worker

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/audit.pm
+++ b/lib/LibreCat/App/Catalogue/Route/audit.pm
@@ -12,6 +12,7 @@ use Dancer ':syntax';
 use Dancer::Serializer::Mutable qw(template_or_serialize);
 use LibreCat::App::Helper;
 use POSIX qw(strftime);
+use LibreCat::Audit;
 use URL::Encode qw(url_decode);
 
 =head2 PREFIX /librecat/audit
@@ -32,11 +33,11 @@ List all audit messages for an :id in the store :bag
         my $bag = params("route")->{bag};
         my $id  = params("route")->{id};
 
-        my $it
-            = h->main_audit()->select(id => $id)->select(bag => $bag)
+        my $it =
+            audit()->select( bag => $bag )->select( id => $id )
             ->sorted(
             sub {
-                $_[0]->{time} cmp $_[1]->{time};
+                $_[0]->{time} <=> $_[1]->{time};
             }
         )->map(
             sub {
@@ -64,19 +65,31 @@ List all audit messages for an :id in the store :bag
             return to_json {error => "Parameter message is missing."};
         }
 
-        my $job_id = h->queue->add_job(
-            'audit',
-            {
-                id      => $id,
-                bag     => $bag,
-                process => 'LibreCat::App::Catalogue::Route::audit',
-                action  => "post /librecat/audit/$bag/$id",
-                message => "$user_id says '$message'",
-            }
-        );
+        my $ar = audit()->add({
+            id      => $id,
+            bag     => $bag,
+            process => 'LibreCat::App::Catalogue::Route::audit',
+            action  => "post /librecat/audit/$bag/$id",
+            message => "$user_id says '$message'",
+        });
 
-        return to_json({job => $job_id});
+        unless($ar){
+
+            #is not supposed to fail as all attributes are given
+            content_type 'json';
+            status 500;
+            return to_json({ error => "unexpected error" });
+
+        }
+
+        return to_json({ _id => $ar->{_id} });
     };
 };
+
+sub audit {
+
+    state $s = LibreCat::Audit->new();
+
+}
 
 1;

--- a/lib/LibreCat/Audit.pm
+++ b/lib/LibreCat/Audit.pm
@@ -1,0 +1,180 @@
+package LibreCat::Audit;
+
+use Catmandu::Sane;
+use Catmandu;
+use Moo;
+use Carp qw(confess);
+use namespace::clean;
+
+extends "LibreCat::Validator::JSONSchema";
+
+has schema => (
+    is => "ro",
+    lazy => 1,
+    default => sub {
+
+        # attribuut 'time' should NOT be added by a user
+        # TODO: restrict to these attributes only?
+        +{
+            '$schema'   => "http://json-schema.org/draft-04/schema#",
+            title       => "librecat audit record",
+            type        => "object",
+            properties  => {
+                id => {
+                    oneOf => [
+                        {
+                            type => "string",
+                            minLength => 1
+                        },
+                        {
+                            type => "integer",
+                            minimum => 0
+                        }
+                    ]
+                },
+                bag => {
+                    type => "string",
+                    minLength => 1
+                },
+                process => {
+                    type => "string",
+                    minLength => 1
+                },
+                action => {
+                    type => "string",
+                    minLength => 1
+                },
+                message => {
+                    type => "string",
+                    minLength => 1
+                }
+            },
+            required => ["id","bag","process","action","message"],
+            additionalProperties => 0
+        };
+    }
+
+);
+
+has bag => (
+    is => "ro",
+    lazy => 1,
+    default => sub {
+        Catmandu->store("main")->bag("audit");
+    },
+    init_arg => undef,
+    handles => "Catmandu::Bag"
+);
+
+around "add" => sub {
+
+    my ($orig, $self, $rec) = @_;
+
+    return unless $self->is_valid( $rec );
+
+    $rec->{time} = time;
+
+    $orig->($self,$rec);
+
+};
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+LibreCat::Audit - model around catmandu bag "audit"
+
+=head1 SYNOPSIS
+
+    use LibreCat::Audit;
+
+    my $audit = LibreCat::Audit->new;
+
+    # add new record to the audit
+
+    my $stored_record = $audit->add({
+        id      => 1,
+        bag     => "publication",
+        process => "librecat publication",
+        action  => "add",
+        message => "I did it"
+    });
+
+    # this package is a subclass of LibreCat::Validator::JSONSchema
+
+    $stored_record  || die( $audit->last_errors() );
+
+    # retrieve all audit records for a specific bag and id
+
+    my $iterator = $audit->select( bag => "publication" )->select( id => 1 );
+
+=head1 DESCRIPTION
+
+This is a L<LibreCat::Validator::JSONSchema> and it expects these, and only these attributes:
+
+    * id:
+        * type: string
+        * minLength: 1
+
+    * bag:
+        * type: string
+        * minLength: 1
+
+    * process:
+        * type: string
+        * minLength: 1
+
+    * action:
+        * type: string
+        * minLength: 1
+
+    * message:
+        * type: string
+        * minLength: 1
+
+Because a L<LibreCat::Validator> is also a L<Catmandu::Validator>, methods like C<is_valid> are available.
+
+All records are stored in C<bag> Catmandu->store("main")->("audit")
+
+All methods calls like C<add> or C<each> are proxied to this underlying bag,
+
+available in the method C<bag>.
+
+It is not recommended however to use this bag directly: the method C<add> for example
+
+checks the validity of the input record before adding it to the bag.
+
+=head1 METHODS
+
+=head1 add( $rec ) : $audit_record
+
+    $rec should like this:
+
+        {
+            bag     => "name_of_bag",
+            id      => "my_id",
+            process => "process_that_is_responsible.pl",
+            action  => "action within process",
+            message => "some random message"
+        }
+
+    $rec is validated against the schema (see DESCRIPTION)
+
+    If the validation fails, it return undef. The errors can be retrieved
+    by issuing the method C<last_errors>, just like any other L<Catmandu::Validator>
+
+    the current 'time' is added to the record automatically
+    before adding it to the underlying bag
+
+    $audit_record should look like the inserted $rec,
+    with the attribute 'time' added to it
+
+=head1 SEE ALSO
+
+L<LibreCat::Validator::JSONSchema>
+
+=cut

--- a/lib/LibreCat/Cmd/audit.pm
+++ b/lib/LibreCat/Cmd/audit.pm
@@ -4,6 +4,7 @@ use Catmandu::Sane;
 use LibreCat::App::Helper;
 use Carp;
 use POSIX qw(strftime);
+use LibreCat::Audit;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -11,13 +12,6 @@ sub description {
 Usage:
 
 librecat audit list [options] [<RECORD-ID>]
-
-An 'audit' worker should be up and running to
-store messages:
-
-Hint:
-
-bin/librecat worker audit start --workers 1 --supervise
 
 EOF
 }
@@ -49,15 +43,19 @@ sub command {
     }
 }
 
+sub audit {
+    state $s = LibreCat::Audit->new();
+}
+
 sub _list {
     my ($self, $pid) = @_;
 
-    my $it = Catmandu->store('main')->bag('audit');
+    my $it = audit()->bag();
 
     if ($pid) {
         $it = $it->select(id => $pid)->sorted(
             sub {
-                $_[0]->{time} cmp $_[1]->{time};
+                $_[0]->{time} <=> $_[1]->{time};
             }
         );
     }

--- a/lib/LibreCat/Cmd/audit.pm
+++ b/lib/LibreCat/Cmd/audit.pm
@@ -1,8 +1,6 @@
 package LibreCat::Cmd::audit;
 
 use Catmandu::Sane;
-use LibreCat::App::Helper;
-use Carp;
 use POSIX qw(strftime);
 use LibreCat::Audit;
 use parent qw(LibreCat::Cmd);
@@ -43,14 +41,10 @@ sub command {
     }
 }
 
-sub audit {
-    state $s = LibreCat::Audit->new();
-}
-
 sub _list {
     my ($self, $pid) = @_;
 
-    my $it = audit()->bag();
+    my $it = LibreCat::Audit->new();
 
     if ($pid) {
         $it = $it->select(id => $pid)->sorted(
@@ -94,11 +88,4 @@ LibreCat::Cmd::audit - manage librecat audit messages
 
     librecat audit list [options] [<RECORD-ID>]
 
-    An 'audit' worker should be up and running to
-    store messages:
-
-    Hint:
-
-    bin/librecat worker audit start --workers 1 --supervise
-    
 =cut

--- a/lib/LibreCat/Cmd/file_store.pm
+++ b/lib/LibreCat/Cmd/file_store.pm
@@ -11,6 +11,7 @@ use File::Path;
 use File::Spec;
 use URI::Escape;
 use POSIX qw(strftime);
+use LibreCat::Audit;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -164,18 +165,19 @@ sub command {
     }
 }
 
+sub audit {
+    state $s = LibreCat::Audit->new();
+}
+
 sub audit_message {
     my ($id, $action, $message) = @_;
-    LibreCat::App::Helper::Helpers->new->queue->add_job(
-        'audit',
-        {
-            id      => $id,
-            bag     => 'publication',
-            process => 'librecat file_store',
-            action  => $action,
-            message => $message,
-        }
-    );
+    audit()->add({
+        id      => $id,
+        bag     => 'publication',
+        process => 'librecat file_store',
+        action  => $action,
+        message => $message,
+    });
 }
 
 sub _list {

--- a/lib/LibreCat/Cmd/file_store.pm
+++ b/lib/LibreCat/Cmd/file_store.pm
@@ -166,12 +166,14 @@ sub command {
 }
 
 sub audit {
-    state $s = LibreCat::Audit->new();
+    my $self = $_[0];
+    $self->{_audit} //= LibreCat::Audit->new();
+    $self->{_audit};
 }
 
 sub audit_message {
-    my ($id, $action, $message) = @_;
-    audit()->add({
+    my ($self, $id, $action, $message) = @_;
+    $self->audit()->add({
         id      => $id,
         bag     => 'publication',
         process => 'librecat file_store',
@@ -299,7 +301,7 @@ sub _get {
     }
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, 'get', $msg);
+        $self->audit_message($key, 'get', $msg);
     }
 
     return 0;
@@ -325,7 +327,7 @@ sub _fetch {
     my $bytes = $files->stream(IO::File->new('>&STDOUT'), $file);
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, "fetch $filename", $msg);
+        $self->audit_message($key, "fetch $filename", $msg);
     }
 
     $bytes > 0;
@@ -356,7 +358,7 @@ sub _add {
     $files->upload(IO::File->new("<$path/$name"), $name);
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, "add $file", $msg);
+        $self->audit_message($key, "add $file", $msg);
     }
 
     return $self->_get($key);
@@ -377,7 +379,7 @@ sub _delete {
     $files->delete($name);
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, "delete $name", $msg);
+        $self->audit_message($key, "delete $name", $msg);
     }
 
     return $self->_get($key);
@@ -395,7 +397,7 @@ sub _purge {
     $store->index->delete($key);
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, 'purge', $msg);
+        $self->audit_message($key, 'purge', $msg);
     }
 
     print "purged $key\n";
@@ -446,7 +448,7 @@ sub _move {
     }
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, "move $name", $msg);
+        $self->audit_message($key, "move $name", $msg);
     }
 
     0;
@@ -579,7 +581,7 @@ sub _export {
     }
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, "export $zip_file", $msg);
+        $self->audit_message($key, "export $zip_file", $msg);
     }
 
     0;
@@ -632,7 +634,7 @@ sub _import {
     }
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, "import $zip_file", $msg);
+        $self->audit_message($key, "import $zip_file", $msg);
     }
 
     0;
@@ -658,7 +660,7 @@ sub _thumbnail {
     my $response = $worker->work({key => $key, filename => $filename,});
 
     if (my $msg = $self->app->global_options->{log}) {
-        audit_message($key, "thumbnail $filename", $msg);
+        $self->audit_message($key, "thumbnail $filename", $msg);
     }
 
     $response && $response->{ok};

--- a/lib/LibreCat/Cmd/publication.pm
+++ b/lib/LibreCat/Cmd/publication.pm
@@ -8,6 +8,7 @@ use LibreCat qw(queue publication timestamp);
 use LibreCat::App::Catalogue::Controller::File;
 use Path::Tiny;
 use Carp;
+use LibreCat::Audit;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -188,18 +189,19 @@ sub command {
     }
 }
 
+sub audit {
+    state $s = LibreCat::Audit->new();
+}
+
 sub audit_message {
     my ($id, $action, $message) = @_;
-    queue->add_job(
-        'audit',
-        {
-            id      => $id,
-            bag     => 'publication',
-            process => 'librecat publication',
-            action  => $action,
-            message => $message,
-        }
-    );
+    audit()->add({
+        id      => $id,
+        bag     => 'publication',
+        process => 'librecat publication',
+        action  => $action,
+        message => $message,
+    });
 }
 
 sub _on_all {

--- a/lib/LibreCat/Cmd/publication.pm
+++ b/lib/LibreCat/Cmd/publication.pm
@@ -190,12 +190,14 @@ sub command {
 }
 
 sub audit {
-    state $s = LibreCat::Audit->new();
+    my $self = $_[0];
+    $self->{_audit} //= LibreCat::Audit->new();
+    $self->{_audit};
 }
 
 sub audit_message {
-    my ($id, $action, $message) = @_;
-    audit()->add({
+    my ($self,$id, $action, $message) = @_;
+    $self->audit()->add({
         id      => $id,
         bag     => 'publication',
         process => 'librecat publication',
@@ -328,7 +330,7 @@ sub _get {
     }
 
     if (my $msg = $self->opts->{log}) {
-        audit_message($id, 'get', $msg);
+        $self->audit_message($id, 'get', $msg);
     }
 
     Catmandu->export($rec, 'YAML') if $rec;
@@ -374,7 +376,7 @@ sub _add {
             }
 
             if (my $msg = $self->opts->{log}) {
-                audit_message($rec->{_id}, 'add', $msg);
+                $self->audit_message($rec->{_id}, 'add', $msg);
             }
         },
     );
@@ -396,7 +398,7 @@ sub _delete {
     if ($result) {
 
         if (my $msg = $self->opts->{log}) {
-            audit_message($id, 'delete', $msg);
+            $self->audit_message($id, 'delete', $msg);
         }
 
         print "deleted $id\n";
@@ -418,7 +420,7 @@ sub _purge {
     if ($result) {
 
         if (my $msg = $self->opts->{log}) {
-            audit_message($id, 'purge', $msg);
+            $self->audit_message($id, 'purge', $msg);
         }
 
         print "purged $id\n";
@@ -638,7 +640,7 @@ sub _checksum_id {
         $pubs->add($rec);
 
         if (my $msg = $self->opts->{log}) {
-            audit_message($rec->{_id}, 'add', $msg);
+            $self->audit_message($rec->{_id}, 'add', $msg);
         }
     }
 
@@ -729,7 +731,7 @@ sub _files_load {
         }
 
         if (my $msg = $self->opts->{log}) {
-            audit_message($id, 'files', $msg);
+            $self->audit_message($id, 'files', $msg);
         }
     };
 

--- a/lib/LibreCat/Worker/Audit.pm
+++ b/lib/LibreCat/Worker/Audit.pm
@@ -53,7 +53,7 @@ LibreCat::Worker::Audit - a worker for audits (if configured)
 
 =head1 DESCRIPTION
 
-Deprecated in favour of L<LibreCat::Auth>
+Deprecated in favour of L<LibreCat::Audit>
 
 =head1 SYNOPSIS
 

--- a/t/LibreCat/Audit.t
+++ b/t/LibreCat/Audit.t
@@ -1,0 +1,68 @@
+use Catmandu::Sane;
+use LibreCat -self => -load => {layer_paths => [qw(t/layer)]};
+use Test::More;
+use Test::Exception;
+
+my $pkg;
+
+BEGIN {
+    $pkg = "LibreCat::Audit";
+    use_ok $pkg;
+}
+
+require_ok $pkg;
+
+my $audit;
+
+lives_ok( sub {
+
+    $audit = $pkg->new();
+
+}, "object of class $pkg created" );
+
+isa_ok $audit, $pkg;
+
+ok $audit->does("LibreCat::Validator");
+can_ok $audit, "add";
+can_ok $audit, "get";
+can_ok $audit, "delete";
+can_ok $audit, "delete_all";
+can_ok $audit, "each";
+can_ok $audit, "select";
+
+dies_ok( sub {
+
+    $audit->is_valid(undef);
+
+}, "$pkg is a Catmandu::Validator, so is_valid must accept hash" );
+
+$audit->bag->delete_all();
+
+#all attributes must be present in the record
+is $audit->add({}), undef;
+is scalar(@{ $audit->last_errors() // [] }), 5;
+
+is $audit->add({ id => 1 }), undef;
+is scalar(@{ $audit->last_errors() // [] }), 4;
+
+is $audit->add({ id => 1, bag => "publication" }), undef;
+is scalar(@{ $audit->last_errors() // [] }), 3;
+
+is $audit->add({ id => 1, bag => "publication", process => "test" }), undef;
+is scalar(@{ $audit->last_errors() // [] }), 2;
+
+is $audit->add({ id => [], bag => "publication", process => "test" }), undef;
+is scalar(@{ $audit->last_errors() // [] }), 3;
+
+$audit->add({ id => 1, bag => "publication", process => "test", action => "get", message => "t" });
+is scalar(@{ $audit->last_errors() // [] }), 0;
+
+#attribute 'time' may never be present
+$audit->add({ id => 1, bag => "publication", process => "test", action => "get", message => "t", time => time });
+is scalar(@{ $audit->last_errors() // [] }), 1;
+
+#acts like a Catmandu::Bag
+is $audit->select( bag => "publication" )->select( id => 2 )->count, 0;
+is $audit->select( bag => "publication" )->select( id => 1 )->count, 1;
+
+done_testing;

--- a/t/LibreCat/Audit.t
+++ b/t/LibreCat/Audit.t
@@ -65,4 +65,9 @@ is scalar(@{ $audit->last_errors() // [] }), 1;
 is $audit->select( bag => "publication" )->select( id => 2 )->count, 0;
 is $audit->select( bag => "publication" )->select( id => 1 )->count, 1;
 
+END {
+    # cleanup test data
+    Catmandu->store('main')->bag('audit')->delete_all;
+}
+
 done_testing;

--- a/t/LibreCat/Cmd/audit.t
+++ b/t/LibreCat/Cmd/audit.t
@@ -19,21 +19,21 @@ BEGIN {
             process => 'batch',
             action  => 'update',
             message => 'test1',
-            time    => '2018-01-01T12:00:00Z'
+            time    => time
         },
         {
             id      => 2,
             process => 'web',
             action  => 'update',
-            time    => '2018-01-01T12:00:02Z'
+            time    => time
         },
-        {id => 3, time => '2018-01-01T12:00:04Z'},
+        {id => 3, time => time},
         {
             id      => 1,
             process => 'batch',
             action  => 'update',
             message => 'change ID 1 again',
-            time    => '2018-01-01T12:00:06Z'
+            time    => time
         },
     ];
     Catmandu->store('main')->bag('audit')->add_many($data);

--- a/t/LibreCat/Hook/audit_message.t
+++ b/t/LibreCat/Hook/audit_message.t
@@ -11,11 +11,6 @@ my $pkg;
 BEGIN {
     $pkg = 'LibreCat::Hook::audit_message';
     use_ok $pkg;
-
-    my $result = test_app(
-        qq|LibreCat::CLI| => ['worker', 'audit', 'start', '--workers', '1']);
-    ok !$result->error, "start worker audit";
-    ok $result->stdout, "start worker audit output";
 }
 
 require_ok $pkg;
@@ -42,22 +37,7 @@ my $data = [
 
 ok $x->fix($_), "apply hook" for @$data;
 
-# Ugly...we need to wait a bit for the audit hooks take effect
-my $audit_data;
-
-my $tries = 0;
-my $sleep = 2;
-while ($tries < 4) {
-    my $audit = Catmandu->store('main')->bag('audit');
-    $audit_data = $audit->to_array;
-
-    if (@$audit_data == 5) {
-        last;
-    }
-
-    sleep($sleep * ($tries + 1));
-    $tries++;
-}
+my $audit_data = $audit->to_array();
 
 is @$audit_data, 5, "5 elements in audit bag";
 
@@ -67,11 +47,6 @@ like $a->{message}, qr/activated/,   "message field present";
 like $a->{bag},     qr/publication/, "bag publication";
 like $a->{time},    qr/\d+/,         "time field present";
 ok $a->{_id},       "_id field present";
-
-my $result = test_app(
-    qq|LibreCat::CLI| => ['worker', 'audit', 'stop', '--workers', '1']);
-ok !$result->error, "stop worker audit";
-ok $result->stdout, "stop worker audit output";
 
 END {
     # cleanup

--- a/t/LibreCat/Worker/Audit.t
+++ b/t/LibreCat/Worker/Audit.t
@@ -22,7 +22,8 @@ my $a = $pkg->new();
 can_ok $a, "work";
 
 my $data = {
-    _id     => 1,
+    id     => 1,
+    process => "process",
     action  => "update",
     bag     => "publication",
     message => "activated",
@@ -37,13 +38,8 @@ my $saved_data = $audit_bag->first;
 like $saved_data->{message}, qr/activated/,   "message field present";
 like $saved_data->{bag},     qr/publication/, "bag publication";
 like $saved_data->{time},    qr/\d+/,         "time field present";
-ok $saved_data->{_id},       "_id field present";
-
-# edge case: no store present
-Catmandu->config->{store}->{main} = undef;
-
-my $b = $pkg->new();
-ok !$b->work($data);
+is   $saved_data->{process},"process", "process field present";
+ok $saved_data->{id},       "id field present";
 
 END {
     # cleanup


### PR DESCRIPTION
Why this is needed: 

* now a worker is needed in order to store messages into the bag "audit", while this actually trivial.

What I changed:

* created a separate package LibreCat::Audit that does both validation and storage. 
  * implements methods from LibreCat::Validator
  * isa LibreCat::Validator::JSONSchema: the schema is located in the package itself. All attributes are required for now (id, bag, process, action and message), and no additional attributes may be added. Suggestions?
  * It uses the same Catmandu->store("main")->bag("audit") as underlying bag
  * bag methods like "add" and "delete" are proxied to that underlying bag
  * records are validated before adding them to the underlying bag

* fixed sorting of audit records: attribute "time" is supposed to be an integer, but is often sorted as a string (using "cmp").

* tests assumed that the attribute "time" could also be a string. These tests did not fail because SQLite accepts strings even if the column is marked as integer. This does not work for other systems.

* deprecated worker LibreCat::Worker::Audit. Remaining messages will be resolved by this worker, but new messages will be sent to LibreCat::Audit directly. So you can shut this one off.

P.S. who/what actually uses the route "post /librecat/audit/:bag/:id" ?