### PR TITLE
Reimplementing store for temporary files

### DIFF
--- a/config/catmandu.local.yml-example
+++ b/config/catmandu.local.yml-example
@@ -1,6 +1,9 @@
 # Public location of the application
 uri_base: "http://localhost:5001"
 
+# Contact address of an administrator
+admin_email: librecat@somewhere.org
+
 # API configuration
 # change at least the token secret! This should be a long random string
 # E.g. see https://onlinerandomtools.com/generate-random-string

--- a/config/files.yml
+++ b/config/files.yml
@@ -74,6 +74,7 @@ access_thumbnailer:
     options:
         files: *filestore_settings
         access: *accessstore_settings
+        tmpdir: data/tmp
 
 # Which ip-ranges can access the file api (not for end-users)
 api:

--- a/config/files.yml
+++ b/config/files.yml
@@ -67,7 +67,7 @@ uploader:
     options:
         files: *filestore_settings
         temp_files: *tempstore_settings
-        
+
 # Worker that generates thumbnail files
 access_thumbnailer:
     package: 'LibreCat::Worker::ImageResizer'

--- a/config/files.yml
+++ b/config/files.yml
@@ -2,8 +2,6 @@
 _prefix:
   filestore:
 
-tmp_dir: data/temp_uploads
-
 #  Configurable name of the download file
 #  options:
 #     %i: publication id
@@ -30,34 +28,57 @@ download_file_name: "%o"
 #    "text/plain":
 #      "Content-Type": "%s; charset=utf-8"
 
+# Main location of all the uploaded files
 default: &filestore_settings
+    # Options for the default store:
+    #   - Simple
+    #   - BagIt (requires Catmandu::BagIt)
+    #   - Multi (requires in store.yml definitions of multiple file stores)
     package: Simple
     options:
         # Optional calculate MD5 checksums on the fly
         # default_plugins: [ 'DynamicChecksum' ]
         root: data/file_uploads
 
-api:
-    buffer_size: 8192
-    access:
-        # Which ip-ranges can access the file api (not for end-users)
-        ip_range:
-            - 127.0.0.1
-            - 10.0.0.0/8
-
-uploader:
-    package: 'LibreCat::Worker::FileUploader'
-    options:
-        files: *filestore_settings
-
-# Thumbnails
+# Main locaton of all thumbnail images
 access: &accessstore_settings
     package: Simple
     options:
         root: data/file_uploads
 
+# Main location of all temporary uploads
+temp: &tempstore_settings
+    # Mandatory: temp store need to be a Simple store
+    package: Simple
+    options:
+        root: data/temp_uploads
+        # Automatic clean up of temporary uploads when they are archived
+        autocleanup: 0
+        # Create a date based mapping of temporary data on disk
+        directory_index_package: Map
+        # Database to store the path mappings
+        directory_index_options:
+            store_name: main
+            bag_name: temp_files
+
+# Worker that imports/deletes files from the filestore
+uploader:
+    package: 'LibreCat::Worker::FileUploader'
+    options:
+        files: *filestore_settings
+        temp_files: *tempstore_settings
+        
+# Worker that generates thumbnail files
 access_thumbnailer:
     package: 'LibreCat::Worker::ImageResizer'
     options:
         files: *filestore_settings
         access: *accessstore_settings
+
+# Which ip-ranges can access the file api (not for end-users)
+api:
+    buffer_size: 8192
+    access:
+        ip_range:
+            - 127.0.0.1
+            - 10.0.0.0/8

--- a/config/files.yml
+++ b/config/files.yml
@@ -53,7 +53,7 @@ temp: &tempstore_settings
     options:
         root: data/temp_uploads
         # Automatic clean up of temporary uploads when they are archived
-        autocleanup: 0
+        autocleanup: 1
         # Create a date based mapping of temporary data on disk
         directory_index_package: Map
         # Database to store the path mappings

--- a/config/log4perl.yml
+++ b/config/log4perl.yml
@@ -7,6 +7,7 @@ log4perl: |
   log4perl.category.LibreCat::Search=INFO,FILE
   log4perl.category.LibreCat::Queue=INFO,FILE2
   log4perl.category.LibreCat::Worker=INFO,STDERR,FILE
+  log4perl.category.LibreCat::App::Catalogue::Controller::File=INFO,STDERR,FILE
   log4perl.appender.STDERR=Log::Log4perl::Appender::Screen
   log4perl.appender.STDERR.stderr=1
   log4perl.appender.STDERR.utf8=1

--- a/config/store.yml
+++ b/config/store.yml
@@ -41,6 +41,8 @@ main:
         # id_generator: Incremental
       reqcopy:
         plugins: []
+      temp_files:
+        plugins: []
 
 search:
   package: ElasticSearch
@@ -1219,4 +1221,3 @@ search:
                 '<=': true
               field: start_date
             end_date: *start_date
-

--- a/cpanfile
+++ b/cpanfile
@@ -21,7 +21,7 @@ on 'test' => sub {
 requires 'Business::ISBN', 0;
 
 # Catmandu
-requires 'Catmandu', '>=1.0606';
+requires 'Catmandu', '>=1.0606, !=1.20';
 requires 'Catmandu::FileStore', '1.13';
 requires 'Catmandu::ArXiv', '0.211';
 requires 'Catmandu::BagIt' , '0.234';

--- a/lib/LibreCat/App/Catalogue/Controller/File.pm
+++ b/lib/LibreCat/App/Catalogue/Controller/File.pm
@@ -7,7 +7,6 @@ Helper methods for handling file uploads.
 =cut
 
 use Catmandu::Sane;
-use Catmandu::Util qw(as_utf8);
 use Catmandu;
 use LibreCat qw(publication timestamp);
 use LibreCat::App::Helper;
@@ -70,7 +69,7 @@ sub upload_temp_file {
     my $now          = timestamp;
     my $tempid       = Data::Uniqid::uniqid;
     my $temp_file    = $file->{tempname};
-    my $file_name    = _cleanup_filename($file->{filename});
+    my $file_name    = h->cleanup_filename($file->{filename});
     my $file_size    = int($file->{size});
     my $content_type = $file->{headers}->{"Content-Type"};
     my $rac_email    = $file->{rac_email} // '';
@@ -182,7 +181,7 @@ sub handle_file {
 
         # If we have a tempid, then there is a file upload waiting...
         if ($fi->{tempid} && $fi->{tempid} =~ /^\S+/) {
-            my $filename = $fi->{file_name} = _cleanup_filename($fi->{file_name});
+            my $filename = $fi->{file_name} = h->cleanup_filename($fi->{file_name});
             my $path     = Dancer::FileUtils::path(
                                 h->config->{filestore}->{tmp_dir},
                                 $fi->{tempid},
@@ -571,13 +570,6 @@ sub _find_deleted_files {
     }
 
     return @filtered_files;
-}
-
-sub _cleanup_filename {
-    my ($filename) = @_;
-    $filename = as_utf8($filename);
-    $filename =~ s/[^\w_\-\.]+/_/g;
-    $filename;
 }
 
 1;

--- a/lib/LibreCat/App/Catalogue/Controller/File.pm
+++ b/lib/LibreCat/App/Catalogue/Controller/File.pm
@@ -286,6 +286,19 @@ sub handle_file {
             {
                 $has_first_changed = 1;
             }
+            # Check if there wasn't any file and this is the first one
+            elsif (
+                   $count == 0
+                   && $pub->{file}->[0]
+                   && ! $prev_pub->{file}->[0]
+            )
+            {
+                $has_first_changed = 1;
+            }
+            else {
+                # this file didn't go to first positio or isn't a new
+                # file in first postition
+            }
         }
         else {
             # A new publication with files..
@@ -294,7 +307,11 @@ sub handle_file {
 
         # Regenerate the first thumbnail...
         if ($has_first_changed) {
+            h->log->info("regenerating thumbmail for $key " .  $fi->{file_name});
             _make_thumbnail($key, $fi->{file_name});
+        }
+        else {
+            h->log->info("no thumbmail needed for $key " .  $fi->{file_name});
         }
 
         delete $fi->{tempid} if $fi->{tempid};

--- a/lib/LibreCat/App/Catalogue/Controller/File.pm
+++ b/lib/LibreCat/App/Catalogue/Controller/File.pm
@@ -316,7 +316,7 @@ sub handle_file {
 
         delete $fi->{tempid} if $fi->{tempid};
 
-        if (h->config->{filestore}->{temp}->{autocleanup}) {
+        if (h->config->{filestore}->{temp}->{options}->{autocleanup}) {
             for my $tempid (@$temp_dir) {
                 h->log->debug("removing the temp-id uploads -> $tempid");
                 h->get_temp_store->index->delete($tempid);

--- a/lib/LibreCat/App/Catalogue/Route/upload.pm
+++ b/lib/LibreCat/App/Catalogue/Route/upload.pm
@@ -8,7 +8,7 @@ Route handler for uploading files.
 
 use Catmandu::Sane;
 use Catmandu::Util qw(:is);
-use LibreCat::App::Catalogue::Controller::File qw/upload_temp_file/;
+use LibreCat::App::Catalogue::Controller::File qw/upload_temp_file remove_temp_file/;
 use Dancer ':syntax';
 
 =head1 REST METHODS
@@ -19,7 +19,9 @@ All methods for file uploads
 
 =head2 POST /librecat/upload?file=[FILE_UPLOAD]
 
-Needs a login session.
+Needs a login session. Any login can upload files. These files are given
+a random unique identifier. When these files ids are attached to the publication
+record, they will be moved to a permanent storage when saving the file.
 
 Upload a File to temporary storage. Returns a JSON document containing
 the upload details and default metadata on success or a JSON error
@@ -30,7 +32,6 @@ document on failure:
     'file_name'    => '183589768.pdf',
     'file_size'    => '1174241',
     'tempid'       => 'sK_QXY7vmd',
-    'tempname'     => '/tmp/sK_QXY7vmd.pdf',
     'content_type' => 'application/pdf',
     'access_level' => 'open_access',
     'rac_email'    => 'me@example.com' # in case access_level is rac
@@ -50,9 +51,40 @@ document on failure:
 =cut
 
 post '/librecat/upload' => sub {
-    my $file    = request->upload('file');
-    my $creator = session->{user};
-    return to_json(upload_temp_file($file, $creator));
+    my $file      = request->upload('file');
+    my $creator   = session->{user};
+
+    # Upload the data and add some metadata on the origin of the request...
+    my $res       = upload_temp_file($file, $creator, {
+        address      => request->address,
+        referer      => request->referer,
+    });
+
+    ($res->{success} == 1) ? status(200) : status(500);
+
+    return to_json($res);
+};
+
+=head2 DEL /librecat/upload/ID
+
+Request the deletion of a temporary file upload (when available). This command
+will not remove files from permanent storage. To do this, the complete record
+needs to be saved.
+
+=cut
+
+del '/librecat/upload/:id' => sub {
+    my $fileid    = param("id");
+    my $creator   = session->{user};
+
+    my $res       = remove_temp_file($fileid, $creator, {
+        address      => request->address,
+        referer      => request->referer,
+    });
+
+    ($res->{success} == 1) ? status(200) : status(500);
+
+    return to_json($res);
 };
 
 1;

--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -429,6 +429,18 @@ sub uri_for_file {
     $self->uri_base() . "/download/$pub_id/$file_id$ext";
 }
 
+sub cleanup_filename {
+    my ($self,$filename) = @_;
+    my $cleaned_filename = Catmandu::Util::as_utf8($filename);
+    $cleaned_filename =~ s/[^\w_\-\.]+/_/g;
+    $cleaned_filename;
+}
+
+sub is_valid_filename {
+    my ($self,$filename) = @_;
+    $filename eq $self->cleanup_filename;
+}
+
 sub login_user {
 
     my ($self, $user) = @_;

--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -342,6 +342,19 @@ sub get_access_store {
     $pkg->new(%$access_opts);
 }
 
+sub get_temp_store {
+    my ($self) = @_;
+
+    my $temp_store = $self->config->{filestore}->{temp}->{package};
+    my $temp_opts  = $self->config->{filestore}->{temp}->{options} // {};
+
+    return undef unless $temp_store;
+
+    my $pkg = Catmandu::Util::require_package($temp_store,
+        'Catmandu::Store::File');
+    $pkg->new(%$temp_opts);
+}
+
 sub show_locale {
     $_[0]->config->{i18n}->{show_locale};
 }
@@ -427,18 +440,6 @@ sub uri_for_file {
     my ($self, $pub_id, $file_id, $file_name) = @_;
     my $ext = $self->file_extension($file_name);
     $self->uri_base() . "/download/$pub_id/$file_id$ext";
-}
-
-sub cleanup_filename {
-    my ($self,$filename) = @_;
-    my $cleaned_filename = Catmandu::Util::as_utf8($filename);
-    $cleaned_filename =~ s/[^\w_\-\.]+/_/g;
-    $cleaned_filename;
-}
-
-sub is_valid_filename {
-    my ($self,$filename) = @_;
-    $filename eq $self->cleanup_filename;
 }
 
 sub login_user {

--- a/lib/LibreCat/Worker/FileUploader.pm
+++ b/lib/LibreCat/Worker/FileUploader.pm
@@ -3,6 +3,7 @@ package LibreCat::Worker::FileUploader;
 use Catmandu::Sane;
 use Catmandu::Util;
 use IO::File;
+use File::Spec;
 use Moo;
 use namespace::clean;
 
@@ -11,8 +12,10 @@ with 'LibreCat::Worker';
 # Flag this package as intended for standalone use, not to be used as daemon
 sub daemon { 0 }
 
-has files => (is => 'ro', required => 1);
+has files      => (is => 'ro', required => 1);
+has temp_files => (is => 'ro', required => 1);
 has file_store => (is => 'lazy');
+has temp_store => (is => 'lazy');
 
 sub _build_file_store {
     my ($self) = @_;
@@ -25,30 +28,39 @@ sub _build_file_store {
     $pkg->new(%$file_opts);
 }
 
+sub _build_temp_store {
+    my ($self) = @_;
+
+    my $temp_store = $self->temp_files->{package};
+    my $temp_opts = $self->temp_files->{options} // {};
+
+    my $pkg = Catmandu::Util::require_package($temp_store,
+        'Catmandu::Store::File');
+    $pkg->new(%$temp_opts);
+}
+
 sub work {
     my ($self, $opts) = @_;
 
-    my $key      = $opts->{key};
-    my $filename = $opts->{filename};
-    my $path     = $opts->{path};
-    $key      = '' unless $key;
-    $filename = '' unless $filename;
-    $path     = '' unless $path;
+    my $key      = $opts->{key}      // '';
+    my $filename = $opts->{filename} // '';
+    my $tempid   = $opts->{tempid}   // '';
+
     my $delete = exists $opts->{delete} && $opts->{delete} == 1 ? "Y" : "N";
 
     $self->log->debug(
-        "key: $key ; filename: $filename ; path: $path ; delete: $delete");
+        "key: $key ; filename: $filename ; tempid: $tempid ; delete: $delete");
 
     if ($delete eq 'Y') {
-        return $self->do_delete($key, $filename, $path, %$opts);
+        return $self->do_delete($key, $filename);
     }
     else {
-        return $self->do_upload($key, $filename, $path, %$opts);
+        return $self->do_upload($key, $filename, $tempid);
     }
 }
 
 sub do_delete {
-    my ($self, $key, $filename, $path, %opts) = @_;
+    my ($self, $key, $filename) = @_;
 
     return -1 unless length $key;
 
@@ -72,11 +84,27 @@ sub do_delete {
 }
 
 sub do_upload {
-    my ($self, $key, $filename, $path, %opts) = @_;
+    my ($self, $key, $filename, $temp_key) = @_;
 
     return -1 unless length $key;
     return -1 unless length $filename;
-    return -1 unless length $path && -f $path && -r $path;
+
+    my $temp_file;
+
+    $self->log->info("searching for the temp file $filename in temp container $temp_key");
+
+    if ($self->temp_store->index->exists($temp_key)) {
+        $temp_file = $self->temp_store->index->files($temp_key)->get($filename);
+    }
+    else {
+        $self->log->error("failed to find $filename in temp container $temp_key");
+        return -1;
+    }
+
+    unless ($temp_file) {
+        $self->log->error("failed to find $filename in temp container $temp_key");
+        return -1;
+    }
 
     $self->log->info("loading container $key");
 
@@ -90,7 +118,24 @@ sub do_upload {
 
     $self->log->info("storing $filename in container $key");
 
-    my $bytes = $files->upload(IO::File->new($path), $filename);
+    ###
+    # Magic to upload temp files via the Catmandu::FileStore
+    # in this code we will assume the temporary store is a
+    # simple store. For these stores we have a hint where the
+    # files are exactly stored.
+
+    unless (ref($self->temp_store) =~ /Catmandu::Store::File::Simple/) {
+        $self->log->fatal("sorry I need a File::Simple store to upload data");
+        die;
+    }
+
+    my $temp_bag       = $self->temp_store->index->files($temp_key);
+    my $temp_abs_path  = File::Spec->catfile(
+                            $temp_bag->_path,
+                            $temp_bag->pack_key($filename)
+                         );
+
+    my $bytes = $files->upload(IO::File->new("<$temp_abs_path"), $filename);
 
     $self->log->info("uploaded $bytes bytes");
 

--- a/lib/LibreCat/Worker/FileUploader.pm
+++ b/lib/LibreCat/Worker/FileUploader.pm
@@ -126,7 +126,7 @@ sub do_upload {
 
     unless (ref($self->temp_store) =~ /Catmandu::Store::File::Simple/) {
         $self->log->fatal("sorry I need a File::Simple store to upload data");
-        die;
+        Catmandu::Error->throw("failed to find a File::Simple implementation of the temp store");
     }
 
     my $temp_bag       = $self->temp_store->index->files($temp_key);
@@ -139,12 +139,14 @@ sub do_upload {
 
     $self->log->info("uploaded $bytes bytes");
 
-    if ($bytes) {
+    my $permanent_file = $self->file_store->index->files($key)->get($filename);
+
+    if ($temp_file->{size} == $permanent_file->{size}) {
         return 1;
     }
     else {
-        $self->log->error("failed to store $filename in container $key");
-        return -1;
+        $self->log->fatal("failed to store $filename in container $key sizes don't match");
+        Catmandu::Error->throw("failed to store $filename in container $key sizes don't match");
     }
 }
 

--- a/lib/LibreCat/Worker/ImageResizer.pm
+++ b/lib/LibreCat/Worker/ImageResizer.pm
@@ -165,6 +165,7 @@ sub extract_to_tmpdir {
     $self->log->debug("creating $tmpdir");
 
     unless (mkdir $tmpdir) {
+        $self->log->error("failed to create $tmpdir : $!");
         return (undef, undef);
     }
 

--- a/lib/LibreCat/Worker/ImageResizer.pm
+++ b/lib/LibreCat/Worker/ImageResizer.pm
@@ -4,6 +4,7 @@ use Catmandu::Sane;
 use Catmandu::Util;
 use Data::Uniqid;
 use File::Spec;
+use Path::Tiny;
 use Moo;
 use namespace::clean;
 
@@ -14,7 +15,7 @@ sub daemon { 0 }
 
 has files          => (is => 'ro', required => 1);
 has access         => (is => 'ro', required => 1);
-has tmpdir         => (is => 'ro', default  => sub {'/tmp'});
+has tmpdir         => (is => 'ro', default  => sub {$ENV{'TMPDIR'} // '/tmp'});
 has buffer_size    => (is => 'ro', default  => sub {8192});
 has thumbnail_size => (is => 'ro', default  => sub {200});
 has file_store   => (is => 'lazy');
@@ -106,7 +107,7 @@ sub do_upload {
     my ($tmpdir, $tmpfile) = $self->extract_to_tmpdir($file);
 
     unless (defined $tmpfile && -r $tmpfile) {
-        $self->log->error(
+        $self->log->fatal(
             "failed to extract $filename from container $key to a temporary directory"
         );
         return {error => 'internal error'};
@@ -119,10 +120,10 @@ sub do_upload {
     my $exit_code = system($cmd);
 
     unless ($exit_code == 0 && -r "$tmpdir/thumb.png") {
-        $self->log->error(
+        $self->log->fatal(
             "failed to generate a thumbnail for $filename from container $key"
         );
-        return {error => 'failed to create thumbail'};
+        return {error => 'failed to create thumbnail'};
     }
 
     # store the results
@@ -145,14 +146,13 @@ sub do_upload {
     $self->log->info("uploaded $bytes bytes");
 
     unless ($bytes) {
-        $self->log->error(
+        $self->log->fatal(
             "failed to create a thumbail for $filename in container $key");
         return {error => 'failed to create thumbnail'};
     }
 
     $self->log->info("cleaning tmpdir $tmpdir");
-    system("rm $tmpdir/*");
-    system("rmdir $tmpdir");
+    path($tmpdir)->remove_tree;
 
     return $bytes ? {ok => 1} : {error => 'failed to create thumbnail'};
 }
@@ -160,7 +160,7 @@ sub do_upload {
 sub extract_to_tmpdir {
     my ($self, $file) = @_;
 
-    my $tmpdir = $self->tmpdir . '/' . Data::Uniqid::suniqid;
+    my $tmpdir = File::Spec->catfile($self->tmpdir,Data::Uniqid::suniqid);
 
     $self->log->debug("creating $tmpdir");
 
@@ -168,7 +168,7 @@ sub extract_to_tmpdir {
         return (undef, undef);
     }
 
-    my $tmpfile = "$tmpdir/" . Data::Uniqid::suniqid;
+    my $tmpfile = File::Spec->catfile($tmpdir,Data::Uniqid::suniqid);
 
     $self->log->debug("streaming to $tmpfile");
 

--- a/public/javascripts/librecat.js
+++ b/public/javascripts/librecat.js
@@ -440,7 +440,7 @@ function link_person(element){
  * @param fileId = file ID
  * @param id = record ID
  */
-function edit_file(fileId, id){
+function edit_file(fileId){
         var json = jQuery.parseJSON($('#file_' + fileId).val());
         if(json.file_id){
                 $('#id_file_id').val(json.file_id);
@@ -448,7 +448,6 @@ function edit_file(fileId, id){
         if(json.tempid){
                 $('#id_temp_id').val(json.tempid);
         }
-        $('#id_record_id').val(id);
         $('#id_fileName').val(json.file_name);
         $('#id_creator').val(json.creator);
         $('#id_fileSize').val(json.file_size);
@@ -510,16 +509,23 @@ function edit_file(fileId, id){
  * Delete uploaded files
  *
  * @param fileId = file ID
- * @param id = record ID
- * @param fileName = file name
  */
 function delete_file(fileId){
         if (confirm("Are you sure you want to delete this uploaded document? Any external links will be broken!\nIf you need to update an existing file to a new version you should edit the corresponding entry in the list and re-upload the file.\n\nDelete this file?")) {
-                $('#' + fileId).remove();
+            $('#' + fileId).remove();
             if($('#uploadFiles').children('.dz-file-preview').length == 0){
                 $('#ddc').find('div.mandatory').removeClass('mandatory');
                 $('#ddc').find('select.required').removeClass('required');
             }
+
+            /* Request removing the fileId also on the server */
+            $.ajax({
+                url:  librecat.uri_base + '/librecat/upload/' + fileId,
+                type: 'DELETE',
+                success: function(result) {
+                    // all's well that ends well
+                },
+            });
         }
         return false;
 }
@@ -529,7 +535,7 @@ function delete_file(fileId){
  */
 $(function () {
         $(".dropzone").sortable({
-                containerSelector: 'div.dz-preview',
+            containerSelector: 'div.dz-preview',
             itemSelector: 'div.dz-preview',
             update: function (event, ui) {
                 var id = ui.item.attr('id');
@@ -540,19 +546,19 @@ $(function () {
 
         $(".creator").sortable({
             update: function (event, ui) {
-                        ui.item.closest('.creator').find('div.row.multirow').each(function(index){
-                                var myitem = $(this);
-                            myitem.find('input, textarea, img, button, select, span').each(function(){
-                                        if($(this).attr('id')){
-                                                var newid = $(this).attr('id').replace(/\d+/g,index);
-                                                $(this).attr('id', newid);
-                                        }
-                                        if($(this).attr('name')){
-                                                var newname = $(this).attr('name').replace(/\d+/g,index);
-                                                $(this).attr('name', newname);
-                                        }
-                                });
+                ui.item.closest('.creator').find('div.row.multirow').each(function(index){
+                    var myitem = $(this);
+                    myitem.find('input, textarea, img, button, select, span').each(function(){
+                        if($(this).attr('id')){
+                                var newid = $(this).attr('id').replace(/\d+/g,index);
+                                $(this).attr('id', newid);
+                        }
+                        if($(this).attr('name')){
+                                var newname = $(this).attr('name').replace(/\d+/g,index);
+                                $(this).attr('name', newname);
+                        }
                     });
+                });
                 ui.item.removeClass("dragged").removeAttr("style");
                 $("body").removeClass("dragging");
             }

--- a/public/javascripts/librecat_dropzones.js
+++ b/public/javascripts/librecat_dropzones.js
@@ -126,7 +126,7 @@ $(document).ready(function(){
 
                     var editLink = Dropzone.createElement("<div class=\"corner_down\" id=\"cordown_" + resp.tempid + "\"><a href=\"#\" onclick=\"return false;\"><span class=\"fa fa-pencil\"></span></a></div>");
                     editLink.addEventListener("click", function(e) {
-                        window.edit_file(resp.tempid, "[% _id %]");
+                        window.edit_file(resp.tempid);
                     });
                     file.previewElement.appendChild(editLink);
 
@@ -156,13 +156,13 @@ $(document).ready(function(){
                 }
             });
             this.on("error", function(file, errorMessage){
-                var modal = Dropzone.createElement("<div class='alert alert-danger'>" + errorMessage + "</div>");
+                var modal = Dropzone.createElement("<div class='alert alert-danger'>" + htmlEscape(errorMessage.error_message) + " This file will be ignored</div>");
                 file.previewElement.appendChild(modal);
             });
             this.on("complete", function(file){
     		    var remove_link = file.previewElement.getElementsByClassName('dz-remove');
     			$(remove_link).remove();
-              $('html').css({ cursor: "auto" });
+                $('html').css({ cursor: "auto" });
     		});
         },
     };

--- a/public/javascripts/librecat_dropzones.js
+++ b/public/javascripts/librecat_dropzones.js
@@ -3,12 +3,17 @@
  */
 $(document).ready(function(){
     var htmlEscape = function(str) {
-        return str
-            .replace(/&/g, '&amp;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;');
+        if (typeof str == 'undefined') {
+            return str;
+        }
+        else {
+            return str
+                .replace(/&/g, '&amp;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+        }
     };
 
     Dropzone.options.qaeUpload = {
@@ -23,7 +28,7 @@ $(document).ready(function(){
         init: function(){
             $('.dz-default.dz-message').addClass('qae');
             this.on("addedfile", function(file) {
-                var fileName = Dropzone.createElement("<div class=\"row\"><div class=\"progress progress-striped active\"><div class=\"progress-bar\" id=\"" + file.name + "_progress\" style=\"width:0;text-align:left;padding-left:10px;\">" + file.name + "</span></div></div></div>");
+                var fileName = Dropzone.createElement("<div class=\"row\"><div class=\"progress progress-striped active\"><div class=\"progress-bar\" id=\"" + htmlEscape(file.name) + "_progress\" style=\"width:0;text-align:left;padding-left:10px;\">" + file.name + "</span></div></div></div>");
                 file.previewElement.appendChild(fileName);
             });
             this.on("uploadprogress", function(file,progress,bytesSent){
@@ -36,21 +41,21 @@ $(document).ready(function(){
                 $(progresselement).remove();
                 var resp = response;//JSON.parse(response);
                 var modal = Dropzone.createElement(
-"<div class='well' id='" + resp.tempname + "'>" +
-"<form id='form_" + resp.tempname + "' action='" + librecat.uri_base + "/librecat/upload/qae/submit' method='post'>" +
-"<strong>" + file.name + "</strong>" +
+"<div class='well' id='" + htmlEscape(resp.tempname) + "'>" +
+"<form id='form_" + htmlEscape(resp.tempname) + "' action='" + librecat.uri_base + "/librecat/upload/qae/submit' method='post'>" +
+"<strong>" + htmlEscape(file.name) + "</strong>" +
 "<textarea class='form-control' placeholder='Type details about your publication here' name='description'>" +
 "</textarea>" +
 "<input type='hidden' name='reviewer' value='" + $('#qaeUpload').data('reviewer') + "' />" +
 "<input type='hidden' name='project_reviewer' value='" + $('#qaeUpload').data('project_reviewer') + "' />" +
 "<input type='hidden' name='delegate' value='" + $('#qaeUpload').data('delegate') + "'/>" +
-"<input type='hidden' name='file_name' value='" + resp.file_name + "' />" +
+"<input type='hidden' name='file_name' value='" + htmlEscape(resp.file_name) + "' />" +
 "<div class='checkbox'>" +
 "<label>" +
 "<input type='checkbox' required> I have read and accept the <a href='" + librecat.uri_base + "/docs/howto/policy#depositpolicy' target='_blank'>PUB Deposit Policy</a>" +
 "</label>" +
 "</div>" +
-"<input type='hidden' name='tempid' value='" + resp.tempid + "' />" +
+"<input type='hidden' name='tempid' value='" + htmlEscape(resp.tempid) + "' />" +
 "<input type='submit' class='btn btn-success' name='submit_or_cancel' value='Submit'/>" +
 "<input type='reset' class='btn btn-warning' onclick='location.reload()' name='submit_or_cancel' value='Cancel' />" +
 "</form></div>"
@@ -58,7 +63,7 @@ $(document).ready(function(){
                 file.previewElement.appendChild(modal);
             });
             this.on("error", function(file, errorMessage){
-                var modal = Dropzone.createElement("<div class='alert alert-danger'>" + errorMessage + "</div>");
+                var modal = Dropzone.createElement("<div class='alert alert-danger'>" + htmlEscape(errorMessage.error_message) + "</div>");
                 file.previewElement.appendChild(modal);
             });
             this.on("complete", function(file){
@@ -78,7 +83,7 @@ $(document).ready(function(){
             $('.dz-default.dz-message').addClass('col-md-11');
             this.on("addedfile", function(file) {
                 $('html').css({ cursor: "wait" });
-                var fileName = Dropzone.createElement("<div class=\"row\"><div class=\"progress progress-striped active\"><div class=\"progress-bar\" id=\"" + file.name + "_progress\" style=\"width:0;text-align:left;padding-left:10px;\">" + file.name + "</span></div></div></div>");
+                var fileName = Dropzone.createElement("<div class=\"row\"><div class=\"progress progress-striped active\"><div class=\"progress-bar\" id=\"" + htmlEscape(file.name) + "_progress\" style=\"width:0;text-align:left;padding-left:10px;\">" + htmlEscape(file.name) + "</span></div></div></div>");
                 file.previewElement.appendChild(fileName);
             });
             this.on("uploadprogress", function(file,progress,bytesSent){
@@ -94,37 +99,37 @@ $(document).ready(function(){
                 if(resp.success){
                     $(file.previewElement).addClass("alert alert-success");
 
-                    var fileName = Dropzone.createElement("<div class=\"row\"><div class=\"col-md-12 padded text-muted\" id=\"filename_" + resp.tempid + "\"><span class=\"fa fa-file text-muted\"></span> <strong>" + file.name + "</strong></div></div>");
+                    var fileName = Dropzone.createElement("<div class=\"row\"><div class=\"col-md-12 padded text-muted\" id=\"filename_" + htmlEscape(resp.tempid) + "\"><span class=\"fa fa-file text-muted\"></span> <strong>" + htmlEscape(file.name) + "</strong></div></div>");
                     file.previewElement.appendChild(fileName);
 
                     var tagsRow = Dropzone.createElement("<div class=\"row\"><div class=\"col-md-2 text-muted\">Access Level:</div><div class=\"col-md-3 text-muted\">Upload Date:</div><div class=\"col-md-3 text-muted\">User:</div><div class=\"col-md-4 text-muted\">Relation:</div></div>");
                     file.previewElement.appendChild(tagsRow);
 
-                    var accessString = Dropzone.createElement("<div class=\"row\"><div class=\"col-md-2\" id=\"access_" + resp.tempid + "\"><span>" + resp.access_level + "</span></div></div>");
+                    var accessString = Dropzone.createElement("<div class=\"row\"><div class=\"col-md-2\" id=\"access_" + htmlEscape(resp.tempid) + "\"><span>" + htmlEscape(resp.access_level) + "</span></div></div>");
                     fileName.appendChild(accessString);
 
-                    var dateString = Dropzone.createElement("<div class=\"col-md-3\" id=\"updated_" + resp.tempid + "\"><span>" + resp.date_updated + "</span></div>");
+                    var dateString = Dropzone.createElement("<div class=\"col-md-3\" id=\"updated_" + htmlEscape(resp.tempid) + "\"><span>" + htmlEscape(resp.date_updated) + "</span></div>");
                     accessString.appendChild(dateString);
 
-                    var userString = Dropzone.createElement("<div class=\"col-md-3\" id=\"creator_" + resp.tempid + "\"><span>" + resp.creator + "</span></div>");
+                    var userString = Dropzone.createElement("<div class=\"col-md-3\" id=\"creator_" + htmlEscape(resp.tempid) + "\"><span>" + htmlEscape(resp.creator) + "</span></div>");
                     accessString.appendChild(userString);
 
-                    var relationString = Dropzone.createElement("<div class=\"col-md-4\" id=\"relation_" + resp.tempid + "\"><span>" + resp.relation + "</span></div>");
+                    var relationString = Dropzone.createElement("<div class=\"col-md-4\" id=\"relation_" + htmlEscape(resp.tempid) + "\"><span>" + htmlEscape(resp.relation) + "</span></div>");
                     accessString.appendChild(relationString);
 
                     file.previewElement.appendChild(accessString);
 
-                    var racString = Dropzone.createElement("<div class=\"row\" id=\"rac_" + resp.tempid + "\"></div>");
+                    var racString = Dropzone.createElement("<div class=\"row\" id=\"rac_" + htmlEscape(resp.tempid) + "\"></div>");
                     file.previewElement.appendChild(racString);
 
-                    var removeLink = Dropzone.createElement("<div class=\"corner_up\" id=\"corup_" + resp.tempid + "\"><a href=\"#\"><span class=\"fa fa-times\"></span></a></div>");
+                    var removeLink = Dropzone.createElement("<div class=\"corner_up\" id=\"corup_" + htmlEscape(resp.tempid) + "\"><a href=\"#\"><span class=\"fa fa-times\"></span></a></div>");
                     removeLink.addEventListener("click", function(e) {
                         window.delete_file(resp.tempid);
                         e.preventDefault();
                     });
                     file.previewElement.appendChild(removeLink);
 
-                    var editLink = Dropzone.createElement("<div class=\"corner_down\" id=\"cordown_" + resp.tempid + "\"><a href=\"#\" onclick=\"return false;\"><span class=\"fa fa-pencil\"></span></a></div>");
+                    var editLink = Dropzone.createElement("<div class=\"corner_down\" id=\"cordown_" + htmlEscape(resp.tempid) + "\"><a href=\"#\" onclick=\"return false;\"><span class=\"fa fa-pencil\"></span></a></div>");
                     editLink.addEventListener("click", function(e) {
                         window.edit_file(resp.tempid);
                     });

--- a/t/LibreCat/Worker/FileUploader.t
+++ b/t/LibreCat/Worker/FileUploader.t
@@ -1,6 +1,10 @@
 use Catmandu::Sane;
 use Test::More;
 use Test::Exception;
+use IO::File;
+use Catmandu;
+use Catmandu::DirectoryIndex::Map;
+use Catmandu::Store::DBI;
 
 my $pkg;
 
@@ -11,19 +15,59 @@ BEGIN {
 
 require_ok $pkg;
 
-my $opts = {package => 'Simple', options => {root => './t/data3'}};
+my $temp_directory = Catmandu::DirectoryIndex::Map->new(
+    base_dir => "t/tmp",
+    bag      => Catmandu::Store::DBI->new(
+                    data_source => "dbi:SQLite:dbname=t/tmp/temp_index.db"
+                )->bag()
+);
 
-dies_ok {$pkg->new()} 'die ok: no args';
-lives_ok {$pkg->new(files => $opts, access => $opts)}
-'lives ok: required args';
+my $file_opts = {
+            package => 'Simple',
+            options => {
+                root => './t/data3'
+            }
+        };
 
-my $uploader = $pkg->new(files => $opts, access => $opts);
+my $temp_opts = {
+            package => 'Simple',
+            options => {
+                root => './t/tmp' ,
+                autocleanup => 1  ,
+                directory_index => $temp_directory  ,
+            }
+        };
+
+my $temp_bag = Catmandu->store('File::Simple', %{$temp_opts->{options}});
+
+# Add some sample data to the temp_store
+ok $temp_bag->index->add({ _id => '9000' });
+
+ok $temp_bag->index->files('9000')->upload(
+        IO::File->new('<README.md'), 'README.md'
+);
+
+dies_ok {
+        $pkg->new()
+} 'die ok: no args';
+
+lives_ok {
+    $pkg->new(
+        files      => $file_opts,
+        temp_files => $temp_opts,
+    )
+} 'lives ok: required args';
+
+my $uploader = $pkg->new(
+                    files      => $file_opts,
+                    temp_files => $temp_opts,
+                );
 can_ok $uploader, 'work';
 
 my $ret;
 lives_ok {
     $ret = $uploader->work(
-        {key => 1, filename => 'README.md', path => 'README.md'})
+        {key => 1, filename => 'README.md', tempid => '9000'})
 }
 "Calling work is safe.";
 

--- a/t/api/librecat-api.t
+++ b/t/api/librecat-api.t
@@ -114,6 +114,18 @@ subtest "add/get/delete publication" => sub {
         '/api/v1/publication' => {Authorization => $token} => json => $pub)
         ->status_is(201)->json_is('/data/id', 999999999);
 
+    $t->put_ok(
+        '/api/v1/publication/999999999' => {Authorization => $token} => json => $pub)
+        ->status_is(200)->json_is('/data/id', 999999999);
+
+    # Change the pub record id and check for errors
+    $pub->{_id} = '1234567890';
+
+    $t->put_ok(
+        '/api/v1/publication/999999999' => {Authorization => $token} => json => $pub)
+        ->status_is(400)
+        ->json_is('/errors/0/validation_error/0', "id in request and data don't match");
+
     $t->get_ok('/api/v1/publication/999999999' => {Authorization => $token})
         ->status_is(200)->json_has('/data/attributes')
         ->json_is('/data/id',             999999999)
@@ -125,10 +137,16 @@ subtest "add/get/delete publication" => sub {
         ->json_is('/data/id',               999999999)
         ->json_is('/data/attributes/title', 'Test patch request');
 
+    # Patch with a wrong id
+    $t->patch_ok(
+        '/api/v1/publication/999999999' => {Authorization => $token} =>
+            json => {_id => '1234567890'})->status_is(400)
+        ->json_is('/errors/0/validation_error/0', "id in request and data don't match");
+
     $t->get_ok('/api/v1/publication/999999999/versions' =>
             {Authorization => $token})->status_is(200)
         ->json_is('/data/id',                    999999999)
-        ->json_is('/data/attributes/0/_version', '2');
+        ->json_is('/data/attributes/0/_version', '3');
 
     $t->get_ok('/api/v1/publication/999999999/version/1' =>
             {Authorization => $token})->status_is(200)


### PR DESCRIPTION
This pull request does:

- Reimplementing the upload location of temporary file uploads
- All file uploads are stored in a File::Simple store with a Map based directory (based on upload date)
- There is an option to keep all uploaded temporary files after they have moved to their permanent location (by default they are cleaned after saving the record)
-  There is a better error handling for temporary uploads and permanent uploads
    - Errors in temporary uploads get an red error message in the form with a descriptive message
    - Errors during moving files to a permanent location get an error page explaining what happened
    - Errors during thumbnail generation are silent (only in the log files)
