### PR TITLE
Fix regex to match any count of whitespaces in split_author

### DIFF
--- a/lib/Catmandu/Fix/split_author.pm
+++ b/lib/Catmandu/Fix/split_author.pm
@@ -43,9 +43,9 @@ sub fix {
 
             $au = (ref $au eq 'ARRAY') ? ($au) : ([$au]);
             foreach my $a (@$au) {
-                if ($a =~ /(\w+.*),\s(\w+.*)/) {
+                if ($a =~ /(\w+.*),\s*(\w+.*)/) {
                     push @{$pub->{$entity}},
-                        {full_name => $a, first_name => $2, last_name => $1};
+                        {full_name => "${1}, ${2}", first_name => $2, last_name => $1};
                 }
                 elsif ($a =~ /(\w+.*?)\s([A-Z]{1,2})(\sJr|\sSr)*$/) {
                     push @{$pub->{$entity}},


### PR DESCRIPTION
Some Sites (e.g. Scopus) omit the whitespace between the author names after the comma in their BibTeX export files. This causes problems in `split_author()` and no author field will be generated in LibreCat. The regex matches both: `Doe, John` and `Doe,John`.