### PR TITLE
Pr/strict web validation

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -42,6 +42,10 @@ header:
     ger: "Deutsch"
   department_affiliation: "Fakultät/ Zugehörigkeit"
   logged_in_as: "Eingeloggt als"
+error:
+  version_conflict: "Ihre Änderungen konnten nicht gespeichert werden. Diese Publikation wurde in der Zwischenzeit von jemand anderem bearbeitet."
+  update_failed: "Publikation %s konnte nicht gespeichert werden. Das Support-Team wurde benachrichtigt."
+  contact_admin: "Bitte kontaktieren Sie %s, falls das Problem bestehen bleibt."
 footer:
   powered_by: "Powered by <a href='http://www.librecat.org/'>LibreCat</a>"
 styles:

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -42,6 +42,10 @@ header:
     ger: "German"
   department_affiliation: "Department Affiliation"
   logged_in_as: "Logged in as"
+error:
+  version_conflict: "Could not save your changes. This publication was updated by someone else since you started editing."
+  update_failed: "Failed to update record %s. The admins have been notified."
+  contact_admin: "Please, contact %s when this problem persists."
 footer:
   powered_by: "Powered by <a href='http://www.librecat.org/'>LibreCat</a>"
 styles:

--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -459,8 +459,11 @@ publication:
       type: string
       description: "Publisher"
     year:
-      type: string
-      pattern: "^\\d{4}$"
+      oneOf:
+        - type: string
+          pattern: "^\\d{4}$"
+        - type: integer
+          pattern: "^\\d{4}$"
       description: "Publication year"
     extern:
       oneOf:

--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -459,9 +459,8 @@ publication:
       type: string
       description: "Publisher"
     year:
-      oneOf:
-        - type: string
-        - type: integer
+      type: string
+      pattern: "^\\d{4}$"
       description: "Publication year"
     extern:
       oneOf:

--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -198,15 +198,6 @@ Checks if the user has the rights to update this record.
             forward '/access_denied';
         }
 
-        # Remember we are dealing with a new record in case
-        # of validation errors...
-        my $is_new_record = 0;
-
-        if ($p->{new_record}) {
-            delete $p->{new_record};
-            $is_new_record = 1;
-        }
-
         $p = h->nested_params($p);
 
         if ($p->{finalSubmit} eq 'recSubmit') {
@@ -225,6 +216,7 @@ Checks if the user has the rights to update this record.
         # that should run before/after updating publications
         my $is_error_record   = 0;
         my $error_messages    = '';
+        my $is_new_record     = $p->{new_record};
         try {
             h->hook('publication-update')->fix_around(
                 $p,
@@ -263,6 +255,9 @@ Checks if the user has the rights to update this record.
         # When we have an error record we return to the edit form and show
         # all errors...
         if ($is_error_record) {
+            # The new_record is a field not available in the schema
+            # which will be removed after validation. We need to se
+            # it again
             $p->{new_record} = 1 if $is_new_record;
 
             my $templatepath = "backend/forms";

--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -44,6 +44,8 @@ Some fields are pre-filled.
 
         return template 'backend/add_new' unless $type;
 
+        # Need to generate a new publication identifier to be
+        # able to load files associated with this new record...
         my $id = publication->generate_id;
 
         # set some basic values
@@ -196,7 +198,14 @@ Checks if the user has the rights to update this record.
             forward '/access_denied';
         }
 
-        delete $p->{new_record};
+        # Remember we are dealing with a new record in case
+        # of validation errors...
+        my $is_new_record = 0;
+
+        if ($p->{new_record}) {
+            delete $p->{new_record};
+            $is_new_record = 1;
+        }
 
         $p = h->nested_params($p);
 
@@ -214,8 +223,8 @@ Checks if the user has the rights to update this record.
 
         # Use config/hooks.yml to register functions
         # that should run before/after updating publications
-        my $is_valid_record   = 1;
-        my $validation_errors = '';
+        my $is_error_record   = 0;
+        my $error_messages    = '';
         try {
             h->hook('publication-update')->fix_around(
                 $p,
@@ -225,8 +234,8 @@ Checks if the user has the rights to update this record.
                         on_validation_error => sub {
                             my ($rec, $errors) = @_;
                             librecat->log->errorf("%s not a valid publication %s", $rec->{_id} // 'NEW', $errors);
-                            $is_valid_record   = 0;
-                            $validation_errors = $errors;
+                            $is_error_record = 1;
+                            $error_messages  = $errors;
                         }
                     );
                 }
@@ -237,28 +246,35 @@ Checks if the user has the rights to update this record.
                     "Could not save your changes. This publication was updated by someone else since you started editing.";
             }
             else {
-                my $id = $p->{_id} // '<new>';
+                my $id = $p->{_id};
                 h->log->fatal("failed to update record $id");
                 h->log->fatal($_);
-                my $admin_email = h->config->{admin_email};
-                my $message =
-    "Failed to update record $id. The admins have been notified. " .
-    "Or, contact $admin_email when this problem persists.";
 
-                flash danger => $message;
+                my $admin_email = h->config->{admin_email};
+
+                $is_error_record = 1;
+                $error_messages = [
+                    "Failed to update record $id. The admins have been notified. " .
+                    "Or, contact $admin_email when this problem persists."
+                ];
             }
         };
 
-        if ($is_valid_record) {
-            redirect $return_url || uri_for('/librecat');
-        }
-        else {
+        # When we have an error record we return to the edit form and show
+        # all errors...
+        if ($is_error_record) {
+            $p->{new_record} = 1 if $is_new_record;
+
             my $templatepath = "backend/forms";
             my $template     = $p->{meta}->{template} // $p->{type};
 
-            flash danger => join("<br>",@{$validation_errors // []});
+            flash danger => join("<br>",@{$error_messages // []});
 
             template "$templatepath/$template", $p;
+        }
+        # Else we return to the return url
+        else {
+            redirect $return_url || uri_for('/librecat');
         }
     };
 

--- a/lib/LibreCat/Cmd/publication.pm
+++ b/lib/LibreCat/Cmd/publication.pm
@@ -347,7 +347,7 @@ sub _add {
         skip_before_add     => $skip_before_add,
         on_validation_error => sub {
             my ($rec, $errors) = @_;
-            $self->log->errorf("%s not va valid publication %s", $rec->{_id}, $errors);
+            $self->log->errorf("%s not a valid publication %s", $rec->{_id}, $errors);
             say STDERR join("\n",
                 $rec->{_id}, "ERROR: not a valid publication", @$errors);
             $ret = 2;


### PR DESCRIPTION
- Making year field in publication a strict `\d{4}` year. 
- Percolating validation errors to the web interface via flash messages
- This as first step to remove the JavaScript based validation.

For now the validation just adds extra syntax validations not covered by the JavaScript validators.