### PR TITLE
move fields from store to index due to stricter checks of the validator

### DIFF
--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -605,18 +605,6 @@ publication:
             oneOf:
               - type: string
               - type: integer
-    pmid:
-      oneOf:
-        - type: string
-          pattern: "^[01]$"
-        - type: integer
-      description: "Flag of PubMed"
-    isi:
-      oneOf:
-        - type: string
-          pattern: "^[01]$"
-        - type: integer
-      description: "Flag of ISI/WoS"
     file:
       type: array
       minItems: 0

--- a/fixes/index_publication.fix
+++ b/fixes/index_publication.fix
@@ -1,9 +1,52 @@
-# add OA flag for open access publications
+#####
+## fix publication data at indexing
+#####
 
+if exists(department)
+  do list(path:department, var:loop)
+    do identity()
+      copy_field(loop._id,loop.tmp)
+      lookup_in_store(loop.tmp, search, bag:department)
+      move_field(loop.tmp.tree, loop.tree)
+      remove_field(loop.tmp)
+    end
+  end
+end
+
+if exists(project)
+  do list(path:project, var:loop)
+    do identity()
+      copy_field(loop._id,loop.tmp)
+      lookup_in_store(loop.tmp, search, bag:project)
+      move_field(loop.tmp.call_identifier,loop.call_identifier)
+      move_field(loop.tmp.grant_number,loop.grant_number)
+      remove_field(loop.tmp)
+      if all_match(loop.call_identifier,'FP7|H2020')
+        add_field(ec_funded,1)
+      end
+    end
+  end
+end
+
+## add flags for ISI/PMID
+if all_match(external_id.isi.0, '^\w+$')
+  add_field(isi, 1)
+end
+if all_match(external_id.pmid.0, '^.+$')
+  add_field(pmid, 1)
+end
+
+## add OA flag for open access publications
 if any_match(file.*.access_level, open_access)
   add_field(oa, 1)
 end
-
 if any_match(main_file_link.*.open_access, 1)
   add_field(oa, 1)
+end
+
+## add flag for OAI output (deleting strategy)
+if all_match(status,"returned|deleted")
+  add_field(oai_deleted, 1)
+else
+  remove_field(oai_deleted)
 end

--- a/fixes/update_publication.fix
+++ b/fixes/update_publication.fix
@@ -1,4 +1,6 @@
-# fix publication data at update
+#####
+## fix publication data at update
+#####
 
 compact(department)
 compact(project)
@@ -10,39 +12,6 @@ clean_preselects()
 person()
 volume_sort()
 
-if exists(department)
-  do list(path:department, var:loop)
-    do identity()
-      copy_field(loop._id,loop.tmp)
-      lookup_in_store(loop.tmp, search, bag:department)
-      move_field(loop.tmp.tree, loop.tree)
-      remove_field(loop.tmp)
-    end
-  end
-end
-
-if exists(project)
-  do list(path:project, var:loop)
-    do identity()
-      copy_field(loop._id,loop.tmp)
-      lookup_in_store(loop.tmp, search, bag:project)
-      move_field(loop.tmp.call_identifier,loop.call_identifier)
-      move_field(loop.tmp.grant_number,loop.grant_number)
-      remove_field(loop.tmp)
-      if all_match(loop.call_identifier,'FP7|H2020')
-        add_field(ec_funded,1)
-      end
-    end
-  end
-end
-
-if all_match(external_id.isi.0, '^\w+$')
-  add_field(isi, 1)
-end
-if all_match(external_id.pmid.0, '^.+$')
-  add_field(pmid, 1)
-end
-
 split_field(nasc, ';|,')
 trim(nasc.*)
 split_field(genbank, ';|,')
@@ -50,13 +19,7 @@ trim(genbank.*)
 split_field(keyword, ';|,')
 trim(keyword.*)
 
-if all_match(status,"returned|deleted")
-  add_field(oai_deleted, 1)
-else
-  remove_field(oai_deleted)
-end
-
-# Force the year field to be a string (see #267)
+## Force the year field to be a string (see GH #267)
 string(year)
 
 remove_field('idm')

--- a/t/records/valid-publication-no-citation.yml
+++ b/t/records/valid-publication-no-citation.yml
@@ -74,12 +74,10 @@ external_id:
   pmid:
     - '25740929'
 intvolume: '        66'
-isi: 1
 issue: '10'
 language:
 - iso: eng
 page: 2979-2990
-pmid: 1
 publication: Journal of Experimental Botany
 publication_identifier:
   issn:

--- a/t/records/valid-publication.yml
+++ b/t/records/valid-publication.yml
@@ -74,12 +74,10 @@ external_id:
   pmid:
     - '25740929'
 intvolume: '        66'
-isi: 1
 issue: '10'
 language:
 - iso: eng
 page: 2979-2990
-pmid: 1
 publication: Journal of Experimental Botany
 publication_identifier:
   issn:


### PR DESCRIPTION
Since version 2 the validation is much stricter (which, of course, is better). Unfortunately some inconsistencies of the past appear. This tries to clean things up:

- Move derived flags to `index_publication.fix`: oai_deleted, isi, pmid. These are set during indexing time now.

- project.call_identifier and project.grant_number are not allowed in schema, so move this to index, too

- deparmtent.tree not in schema, so add this at indexing time

See also the related question in #797 