### PR TITLE
fix bug in cloning functionality

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -427,8 +427,13 @@ Clones the record with ID :id and returns a form with a different ID.
                 {message => "No publication found with ID $id."};
         }
 
+        delete $rec->{_version};
+        delete $rec->{date_created};
+        delete $rec->{date_updated};
+        delete $rec->{doi};
         delete $rec->{file};
         delete $rec->{related_material};
+
         $rec->{_id}        = publication->generate_id;
         $rec->{new_record} = 1;
 

--- a/t/www/edit_record.t
+++ b/t/www/edit_record.t
@@ -12,8 +12,7 @@ my $app = eval {do './bin/app.pl';};
 
 my $mech = Test::WWW::Mechanize::PSGI->new(app => $app);
 
-note("login");
-{
+subtest "login" => sub {
     $mech->get_ok('/login');
 
     $mech->submit_form_ok(
@@ -25,10 +24,9 @@ note("login");
     );
 
     $mech->content_contains("(Admin)", "logged in successfully");
-}
+};
 
-note("edit 2737383");
-{
+subtest "edit record" => sub {
     $mech->get_ok('/librecat/record/edit/2737383');
 
     $mech->has_tag('h1',
@@ -46,6 +44,26 @@ note("edit 2737383");
     );
 
     $mech->content_contains("(Admin)", "logged in successfully");
-}
+};
+
+subtest "clone record" => sub {
+    $mech->get_ok('/librecat/record/clone/2737383');
+
+    $mech->has_tag('h1',
+        'Function of glutathione peroxidases in legume root nodules');
+
+    $mech->submit_form_ok(
+        {
+            form_id => 'edit_form',
+            button  => 'finalSubmit',
+            fields  => {
+
+            },
+        },
+        'submitting the login form'
+    );
+
+    $mech->content_contains("(Admin)", "logged in successfully");
+};
 
 done_testing;


### PR DESCRIPTION
Due the the '_version' field, which shouldn't be present in case of a new
record. Same for the 'date_created' and 'date_updated'; besides the date plugin
in the store will take care of that.