### PR TITLE
provide template for file errors

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/file.pm
+++ b/lib/LibreCat/App/Catalogue/Route/file.pm
@@ -162,7 +162,7 @@ sub _handle_download {
 
     unless ($ok) {
         status 403;
-        return template '403';
+        return template 'file/403';
     }
 
     if (my $file = _file_exists($id, $file_name)) {
@@ -170,8 +170,7 @@ sub _handle_download {
     }
     else {
         status 404;
-        template 'error',
-            {message => "The file does not exist anymore. We're sorry."};
+        template 'file/404';
     }
 }
 

--- a/views/file/403.tt
+++ b/views/file/403.tt
@@ -1,0 +1,21 @@
+[% PROCESS header.tt %]
+
+<!-- BEGIN 403.tt -->
+
+<div class="row"><!-- outer border -->
+
+  <div class="col-md-11 col-sm-12"><!-- main content -->
+
+    <div id="banner">
+	<h1>
+	  [% h.loc("403.heading") %]
+	</h1>
+    </div>
+
+  </div>
+
+</div>
+
+<!-- END 403.tt -->
+
+[% INCLUDE footer.tt %]

--- a/views/file/404.tt
+++ b/views/file/404.tt
@@ -1,0 +1,21 @@
+[% PROCESS header.tt %]
+
+<!-- BEGIN 404.tt -->
+
+<div class="row"><!-- outer border -->
+
+  <div class="col-md-11 col-sm-12"><!-- main content -->
+
+    <div id="banner">
+	<h1>
+	  [% h.loc("404.heading") %]
+	</h1>
+    </div>
+
+  </div>
+
+</div>
+
+<!-- END 404.tt -->
+
+[% INCLUDE footer.tt %]


### PR DESCRIPTION
See https://github.com/LibreCat/LibreCat/issues/790

For backward compatibility, the content for `file/404.tt`and `file/403.tt` is the same
as `404.tt` and `403.tt`.