### PR TITLE
remove references from views/hits.tt to path /marked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ cpanfile.snapshot
 data/file_uploads/**
 data/temp_uploads/**
 docs/
-inc/
 layers.yml
 local/
 logs/*.log

--- a/views/hits.tt
+++ b/views/hits.tt
@@ -1,6 +1,4 @@
 <!-- BEGIN hits.tt -->
-[% num = total; n = 0 -%]
-[%- UNLESS request.path_info.match("/marked") %]
 <div class="row">
   <div class="col-md-12[% UNLESS request.path_info.match("/person") OR total == 0 %] col-xs-8[% END %]">
     <h3 class="margin-top0">[% total %] [% IF total == 1 %][% h.loc("hits.publication") %][% ELSE %][% h.loc("hits.publications") %][% END %]
@@ -15,7 +13,6 @@
   </div>
   [%- END %]
 </div>
-[%- END -%]
 
 [%- IF !backend AND total AND total > 1 %]
 [%- IF request.path_info.match("/person") %]
@@ -27,12 +24,9 @@
       <a class="btn btn-xs mark_all padding0" data-marked="0"><span class="fa fa-square-o fa-lg"></span> [% h.loc("mark.mark_all") %]</a>
       [%- END %]
     </p>
-[%- ELSIF request.path_info.match("/marked") %]
-  <p><a class="btn btn-xs mark_all padding0" data-marked="1"><span class="fa fa-square-o fa-lg"></span> [% h.loc("mark.unmark_all") %]</a></p>
 [%- END %]
 [%- END %]
 
-[%- UNLESS request.path_info.match("/marked") %]
 [%- IF next_page or previous_page %]
 <div class="row">
   [% INCLUDE pagination.tt %]
@@ -40,14 +34,11 @@
 <div class="row margin-top1">
 [%- END %]
 </div>
-[%- END %]
 
 [%- style = style || h.config.citation.csl.default_style %]
 <!-- This publication list is displayed in "[% style %]" style and sorted "[% sorto %]" -->
 [% num = total; n = 0 %]
-[% IF request.path_info == "/marked" %]<ul class="list-unstyled" id="sortable">[% END %]
 [% FOREACH entry IN hits %]
-[% IF request.path_info == "/marked" %]<li class="markedme" id="fade_[% n+1 %]">[% END %]
 <div class="row">
 [% IF backend  %]
   <div class="col-md-1[% IF loop.first %] helpme helpme-md[% END %]" data-placement="top" title="[% h.loc("help.statuses") %]">
@@ -66,14 +57,14 @@
       <span class="text-muted"><strong>[% h.loc("main_page.statuses.private") %]</strong></span>
     [% END %]
   </div>
-[% ELSIF request.path_info == "/marked" OR request.path_info.match("/person") OR request.path_info.match("/record") %]
+[% ELSIF request.path_info.match("/person") OR request.path_info.match("/record") %]
   <div class="col-md-1">
-    [% UNLESS request.path_info == "/marked" %][% UNLESS request.path_info.match("/record") %][[% num - n %]][% END %] [% n = n +1 %]<br>[% END %]
-    [% IF !backend %]<a [% IF request.path_info == "/marked" %]id="clickme_[% n %]" [% END %]class="mark btn btn-xs padding0" data-marked="[% h.is_marked(entry._id) %]" data-id="[% entry._id %]">[% IF h.is_marked(entry._id) %]<span class="fa fa-check-square-o fa-lg"></span>[% ELSE %]<span class="fa fa-square-o fa-lg"></span>[% END %]</a>[% END %]
+    [% UNLESS request.path_info.match("/record") %][[% num - n %]][% END %] [% n = n +1 %]<br>
+    [% IF !backend %]<a class="mark btn btn-xs padding0" data-marked="[% h.is_marked(entry._id) %]" data-id="[% entry._id %]">[% IF h.is_marked(entry._id) %]<span class="fa fa-check-square-o fa-lg"></span>[% ELSE %]<span class="fa fa-square-o fa-lg"></span>[% END %]</a>[% END %]
   </div>
 [% ELSE %]
 [% END %]
-[% IF backend OR request.path_info == "/marked" OR request.path_info.match("/person") OR request.path_info.match("/record") %]
+[% IF backend OR request.path_info.match("/person") OR request.path_info.match("/record") %]
     <div class="col-md-11[% IF backend AND loop.first %] helpme" data-placement="top" title="[% h.loc("help.citation") %][% END %]">
 [% ELSE %]
     <div class="col-md-12">
@@ -104,9 +95,7 @@
 
 <div class="row">&nbsp;</div>
 
-[% IF request.path_info == "/marked" %]</li>[% END %]
 [% END %]
-[% IF request.path_info == "/marked" %]</ul>[% END %]
 
 [%- IF error %]
 <div class="row">

--- a/views/inc/hit/title.tt
+++ b/views/inc/hit/title.tt
@@ -1,0 +1,3 @@
+<!-- BEGIN inc/hit/title.tt -->
+<em>[% IF entry.year %][% entry.year %][% ELSE %][n.d.][% END %] | [% t = entry.type; %] [% h.loc("forms.${t}.label") %] | [% h.loc("hits.id") %]: <span class="pubid">[% entry._id %]</span> [% IF entry.oa %]| <img src="[% uri_base %]/images/access_open.png" class="description" data-toggle="tooltip" data-html="true" data-placement="bottom" rel="tooltip" title="Open access file" alt="OA">[% END %]</em>
+<!-- END inc/hit/title.tt -->

--- a/views/inc/marked/hits.tt
+++ b/views/inc/marked/hits.tt
@@ -1,0 +1,44 @@
+<!-- BEGIN inc/marked/hits.tt -->
+
+<p>
+  <a class="btn btn-xs mark_all padding0" data-marked="1">
+    <span class="fa fa-square-o fa-lg"></span> [% h.loc("mark.unmark_all") %]
+  </a>
+</p>
+
+[%- style = style || h.config.citation.csl.default_style %]
+
+<ul class="list-unstyled" id="sortable">
+[% FOREACH entry IN hits %]
+  <li class="markedme" id="fade_[% look.index %]">
+    <div class="row">
+      <div class="col-md-1">
+        <a id="clickme_[% loop.index %]" class="mark btn btn-xs padding0" data-marked="[% h.is_marked(entry._id) %]" data-id="[% entry._id | html %]">
+        [% IF h.is_marked(entry._id) %]
+          <span class="fa fa-check-square-o fa-lg"></span>
+        [% ELSE %]
+          <span class="fa fa-square-o fa-lg"></span>
+        [% END %]
+        </a>
+      </div>
+      <div class="col-md-11">
+        [% INCLUDE inc/hit/title.tt %]
+        <div class="citation-block-div">
+          [%- IF style == 'short' %]
+          <a href="[% uri_base %]/record/[% entry._id | uri %]"><strong>[% entry.title %]</strong></a><br>
+          [%- END %]
+          [%- IF h.config.citation.engine == 'csl' AND entry.citation.$style %]
+            [% entry.citation.$style %]
+          [%- ELSE %]
+            [% PROCESS citation.tt entry=entry %]
+          [%- END %]
+        </div>
+        [% INCLUDE links.tt %]
+      </div>
+    </div>
+    <div class="row">&nbsp;</div>
+  </li>
+[% END %]
+</ul>
+
+<!-- END inc/marked/hits.tt -->

--- a/views/marked/list.tt
+++ b/views/marked/list.tt
@@ -43,7 +43,7 @@
       <div class="tab-content">
         <div class="tab-pane active">
           <div class="col-sm-8">
-          [% INCLUDE hits.tt %]
+          [% INCLUDE inc/marked/hits.tt %]
           </div>
           <div class="col-md-3 col-md-offset-1 col-sm-4">
           [% PROCESS marked/filters.tt %]


### PR DESCRIPTION
Changes

* removed "inc" from `.gitignore`. This way I can use paths like `views/inc`
* remove references to context "/marked" in `views/hits.tt`.
* create `views/inc/marked/hits.tt`
* `views/marked/list.tt` now refers to `views/inc/marked/hits.tt`

Notes:

* If you overwrite `views/marked/list.tt` in your layer, you should update that in order to use the newer `views/inc/marked/hits.tt`
* If you overwrite `views/hits.tt` in your layer specifically to add behaviour for context `/marked`, then you should move that extra behaviour to `views/inc/marked/hits.tt`