### PR TITLE
cleanup /marked part 2

### DIFF
--- a/views/facets.tt
+++ b/views/facets.tt
@@ -10,8 +10,6 @@
   </div>
 [%- END %]
 
-[%- IF request.path_info != "/marked" -%]
-
   <h3>[%- IF bag == "person" %][% h.loc("facets.filter_authorlist") %]
       [%- ELSE %][% h.loc("facets.filter_publications") %][% END %]</h3>
 
@@ -40,5 +38,3 @@
     [% END %]
     </ul>
   [% END %]
-
-[%- END %]

--- a/views/filters.tt
+++ b/views/filters.tt
@@ -20,7 +20,7 @@
 [% INCLUDE facets.tt %]
 
 [%- IF hits.0.citation OR (total AND total > 1) %]
-<h3[% IF request.path_info.match('marked') %] class="margin-top0"[% END %]>[% h.loc("facets.display") %][% UNLESS request.path_info.match('marked') %] / [% h.loc("facets.sort") %][% END %]</h3>
+<h3>[% h.loc("facets.display") %] / [% h.loc("facets.sort") %]</h3>
 
 [%- IF qp.item('sort') %]
   <div class="text-muted">

--- a/views/marked/filters.tt
+++ b/views/marked/filters.tt
@@ -3,32 +3,19 @@
 [% lang = h.locale() -%]
 
 <!-- BEGIN marked/filters.tt -->
-[%- USE JSON.Escape %]
-<div id="filters"></div>
+<div id="filters" class="anchor"></div>
 <div id="export"></div>
-
 <div class="hidden-sm hidden-md hidden-lg"><hr></div>
 
-[%- IF request.path_info.match("person") AND bag != 'person' %]
-<div class="margin-bottom1">
-  [%- qp.person = id %]
-  <a href="[% request.uri_for("/marked", qp) %]" rel="nofollow"><span class="label label-default total-marked">[% marked %]</span>[% h.loc("mark.marked_publication") %]</a>
-</div>
-[%- END -%]
-
 [%- IF hits.0.citation OR (total AND total > 1) %]
-<h3[% IF request.path_info.match('marked') %] class="margin-top0"[% END %]>[% h.loc("facets.display") %][% UNLESS request.path_info.match('marked') %] / [% h.loc("facets.sort") %][% END %]</h3>
+<h3 class="margin-top0">[% h.loc("facets.display") %]</h3>
 
 [%- IF qp.item('sort') %]
   <div class="text-muted">
     [%- tmp = {}; tmp.import(qp); tmp.delete('sort') %]
     <a href="[% request.uri_for(request.path_info, tmp) %]" rel="nofollow"><span class="fa fa-times"></span></a>
     <strong>[% h.loc("facets.sorted_by") %]:</strong>
-    [% IF bag == "person" %]
-      [% sort_options = h.config.sort_options_person %]
-    [% ELSE %]
-      [% sort_options = h.config.sort_options %]
-    [% END %]
+    [% sort_options = h.config.sort_options %]
     [%- FOREACH setting IN qp.item('sort') %]
       [%- tmp = setting.split('\.') %]
       [% h.loc("facets.sort_options.${tmp.0}") %] <span class="fa fa-arrow-[% IF tmp.1 == 'asc' %]up[% ELSE %]down[% END %]"></span>[% UNLESS loop.last %], [% END %]
@@ -45,25 +32,7 @@
   </div>
 [%- END %]
 
-<ul class="nav nav-tabs nav-stacked ul3[% IF backend %] helpme" data-placement="left" title="[% h.loc("help.display_block") %][% END %]">
-  [% IF (!request.path_info.match('person') OR bag == "person") AND !request.path_info.match('marked') AND total > 9 %]
-  <li>
-    <button data-toggle="collapse" data-target="#hitsperpage_[% tabmodus %][% menu %]" class="btn-link"><span class="fa fa-chevron-down fw"></span>[% h.loc("facets.hits_per_page") %][% IF qp.limit %]: [% limit %][% ELSE %]: [% h.config.default_page_size %][% END %]</button>
-    <div class="facettecollapse">
-    <ul id="hitsperpage_[% tabmodus %][% menu %]" class="collapse">
-      [%- FOREACH lim IN h.config.pagination_options %]
-        [%- IF (qp.limit AND qp.limit == lim) OR (!qp.limit AND lim == h.config.default_page_size) %]
-        <li>[% lim %]</li>
-        [%- ELSE %]
-          [%- tmp = {}; tmp.import(qp); tmp.limit = lim %]
-          <li><a href="[% request.uri_for(request.path_info, tmp) %]" rel="nofollow">[% lim %]</a></li>
-        [%- END %]
-      [%- END %]
-    </ul>
-    </div>
-  </li>
-  [% END %]
-
+<ul class="nav nav-tabs nav-stacked ul3">
   <li>
     <button data-toggle="collapse" data-target="#style" class="btn-link"><span class="fa fa-chevron-down fw"></span>[% h.loc("facets.citation_style") %]</button>
     <div class="facettecollapse">
@@ -82,7 +51,7 @@
 </ul>
 [%- END -%]
 
-<h3>[% h.loc("facets.export") %][% UNLESS backend OR request.path_info.match('marked') OR request.path_info.match('embed') %] / [% h.loc("facets.embed") %][% END %]</h3>
+<h3>[% h.loc("facets.export") %]</h3>
 
 <ul class="nav nav-tabs nav-stacked ul4">
   <li>

--- a/views/search_box.tt
+++ b/views/search_box.tt
@@ -13,7 +13,6 @@
   [%- END %]
 [%- END -%]
 
-[%- UNLESS request.path_info.match('marked') %]
 <h3[%- IF qp.q.size == 0 %] class="margin-top0"[% END %]>[% h.loc("facets.search") %]</h3>
 <form
     id="backend_search_form"
@@ -44,5 +43,4 @@
     [%- END %]
   [%- END %]
 </form>
-[%- END -%]
 <!-- END search_box.tt -->


### PR DESCRIPTION
Cleanup of references to path `/marked`, part 2:

* removed references from `views/facets.tt`: not used in marked
* removed references from `views/filters.tt`: marked has its own`views/marked/filters.tt`
* removed references from `views/search_box.tt`: loaded by `views/filters.tt` which isn't used by marked
* `views/marked/filters.tt`
  * removed references to path_info "/marked", as you're always in that path
  * removed blocks for path "/person/:id"

