### PR TITLE
Fix wos mapping of publishing year

### DIFF
--- a/fixes/wos_mapping.fix
+++ b/fixes/wos_mapping.fix
@@ -100,7 +100,12 @@ end
 move_field(VL,_r.volume)
 move_field(IS,_r.issue)
 move_field(SE,_r.series_title)
-move_field(PY,_r.year)
+if exists(EY)
+  move_field(EY,_r.year)
+end
+if exists(PY)
+  move_field(PY,_r.year)
+end
 
 #if exists(PG)
 #  move_field(PG, _r.page)


### PR DESCRIPTION
Usually the publishing year is delivered in field PY, but sometimes (for epub ahead of print) PY is not present. Instead year is delivered in field EY.

This pr fixes the wos mapping accordingly.