### PR TITLE
Fixes missing publishing year in case of early access publications

### DIFF
--- a/fixes/wos_mapping.fix
+++ b/fixes/wos_mapping.fix
@@ -100,6 +100,12 @@ end
 move_field(VL,_r.volume)
 move_field(IS,_r.issue)
 move_field(SE,_r.series_title)
+if exists(EA)
+  if any_match(EA, '^\w{3} \d{4}')
+    replace_all(EA, '^\w{3} ','')
+    move_field(EA, _r.year)
+  end
+end
 if exists(EY)
   move_field(EY,_r.year)
 end


### PR DESCRIPTION
In case of early access publications, there will be no field PY (publishing year) and no field EY. So, again, we are left without a publishing year.

The field EA contains a date (kind of) in the form of "Nov 2019". This PR adds a change to retrieve the year from this field using a regex.