### PR TITLE
Remove 'sequence' field from authors/editors in crossref import

### DIFF
--- a/fixes/crossref_mapping.fix
+++ b/fixes/crossref_mapping.fix
@@ -33,6 +33,7 @@ do list (path => r.author)
     move(given, first_name)
     move(family, last_name)
     remove(affiliation)
+    remove(sequence)
   end
 end
 
@@ -43,6 +44,7 @@ do list (path => r.editor)
     move(given, first_name)
     move(family, last_name)
     remove(affiliation)
+    remove(sequence)
   end
 end
 


### PR DESCRIPTION
Authors and editors come with a field called "sequence" from crossref. This field causes validation errors on import.

Removing/ignoring it causes no harm because we use the array's order to determine first and additional authors, anyway.