### PR TITLE
remove regexes in dancer routes (where possible)

### DIFF
--- a/lib/LibreCat/App/Search/Route/person.pm
+++ b/lib/LibreCat/App/Search/Route/person.pm
@@ -18,8 +18,8 @@ List persons alphabetically
 
 =cut
 
-get qr{/person} => sub {
-    my $c = params->{browse} // 'a';
+get '/person' => sub {
+    my $c = params("query")->{browse} // 'a';
 
     my %search_params = (
         cql   => ["publication_count>0 AND lastname=" . lc $c . "*"],

--- a/lib/LibreCat/App/Search/Route/project.pm
+++ b/lib/LibreCat/App/Search/Route/project.pm
@@ -34,8 +34,8 @@ Project page with alphabetical browsing.
 
 =cut
 
-get qr{/project/*} => sub {
-    my $c             = params->{browse} // 'a';
+get "/project" => sub {
+    my $c             = params("query")->{browse} // 'a';
     my %search_params = (
         query        => {prefix => {'name.exact' => lc($c)}},
         sru_sortkeys => "name,,1",

--- a/lib/LibreCat/App/Search/Route/publication.pm
+++ b/lib/LibreCat/App/Search/Route/publication.pm
@@ -20,8 +20,9 @@ Export publication with ID :id in format :fmt
 =cut
 
 get '/record/:id.:fmt' => sub {
-    my $id  = params->{id};
-    my $fmt = params->{fmt} // 'yaml';
+    my $rparams = params("route");
+    my $id  = $rparams->{id};
+    my $fmt = $rparams->{fmt} // 'yaml';
 
     forward "/export", {cql => "id=$id", fmt => $fmt , limit => 1};
 };
@@ -70,7 +71,7 @@ Search API to (data) publications.
 
 =cut
 
-get qr{/record/*} => sub {
+get "/record" => sub {
     my $p = h->extract_params();
 
     push @{$p->{cql}}, "status=public";

--- a/t/www/project.t
+++ b/t/www/project.t
@@ -22,7 +22,6 @@ subtest 'project splash page' => sub {
 
 subtest 'project index page' => sub {
     $mech->get_ok('/project');
-    $mech->get_ok('/project/');
 
     $mech->page_links_ok('testing all the links');
 };

--- a/views/project/list.tt
+++ b/views/project/list.tt
@@ -1,8 +1,6 @@
-[%- qp = request.params.hash %]
-[%- qp.delete('splat') %]
 [% PROCESS header.tt %]
 <!-- BEGIN project/list.tt -->
-<span id="language_id" class="hidden">[% lang %]</span>
+<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">


### PR DESCRIPTION
* Replaced regexes from dancer routes: a regex matches too much.
* Could not be done for route `/project/*` because one can use slashes in a project id?