### PR TITLE
Configure validator

### DIFF
--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -1944,3 +1944,50 @@ licenses:
     short: "MPL 2.0"
     deed_url: "https://opensource.org/licenses/MPL-2.0"
     legal_code_url: "https://www.mozilla.org/en-US/MPL/2.0/"
+
+
+validator:
+  jsonschema:
+    errors:
+      object:
+        required: "[_1] is required"
+        additionalProperties: "properties not allowed: [_2]"
+        maxProperties: "too many properties for [_1]: got [_2], maximum [_3] allowed"
+        minProperties: "not enough properties for [_1]: got [_2], minimum [_3] required"
+      string:
+        type: "[_1] must be a string, got [_2]"
+        pattern: "[_1] does not match pattern [_2]"
+        maxLength: "[_1] is too long: got [_2], maximum [_3] allowed"
+        minLength: "[_1] is too short: got [_2], minimum [_3] required"
+      array:
+        type: "[_1] must be an array, got [_2]"
+        uniqueItems: "[_1] must contain unique items"
+        additionalItems: "[_1] contains an invalid number of items: got [_2], maximum [_3] allowed"
+        maxItems: "[_1] contains too many items: got [_2], maximum [_3] allowed"
+        minItems: "[_1] does not contain enough items: got [_2], minimum [_3] required"
+      oneOf:
+        type: "[_1] must be [_2], got [_3]"
+        all_rules_match: "only one rule may apply"
+      allOf:
+        type: "[_1] must be [_2], got [_3]"
+      anyOf:
+        type: "[_1] must be [_2], got [_3]"
+      enum:
+        enum: "allowed values for [_1]: [_2]"
+      const:
+        const: "[_1] does not match constant [_2]"
+      integer:
+        type: "[_1] must be an integer, got [_2]"
+        #[_2]: received value
+        maximum: "[_1] should not be bigger than [_3]"
+        minimum: "[_1] should not be smaller than [_3]"
+        multipleOf: "[_1 ] should contain a multiple of [_1]"
+      number:
+        type: "[_1] must be number, got [_2]"
+        maximum: "[_1] should not be bigger than [_3]"
+        minimum: "[_1] should not be smaller than [_3]"
+        multipleOf: "[_1 ] should contain a multiple of [_1]"
+      not:
+        not: "[_1] should not match"
+      "null":
+        "null": "[_1] should be null"

--- a/cpanfile
+++ b/cpanfile
@@ -36,7 +36,7 @@ requires 'Catmandu::OAI' , '0.16';
 requires 'Catmandu::RIS', '>=0.04';
 requires 'Catmandu::SRU','0.039';
 requires 'Catmandu::Store::ElasticSearch', '>=1.0';
-requires 'Catmandu::Validator::JSONSchema','>=0.12';
+requires 'Catmandu::Validator::JSONSchema','>=0.13';
 requires 'Catmandu::XML';
 requires 'Search::Elasticsearch', '>=6.00';
 requires 'Search::Elasticsearch::Client::6_0';

--- a/lib/LibreCat.pm
+++ b/lib/LibreCat.pm
@@ -7,7 +7,7 @@ use Config::Onion;
 use Log::Log4perl;
 use Log::Any::Adapter;
 use Path::Tiny;
-use Catmandu::Util qw(is_ref is_hash_ref require_package use_lib read_yaml);
+use Catmandu::Util qw(is_ref is_hash_ref require_package use_lib read_yaml is_string);
 use List::MoreUtils qw(any);
 use String::CamelCase qw(camelize);
 use POSIX qw(strftime);

--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -258,8 +258,9 @@ Checks if the user has the rights to update this record.
                                 "%s not a valid publication %s",
                                 $rec->{_id} // 'NEW', [map { $_->{message} } @$errors]);
                             $is_error_record = 1;
+                            my $current_locale = h->locale();
                             $error_messages  = [ map {
-                                localize( @{ $_->{i18n} } );
+                                $_->localize( $current_locale );
                             } @$errors ];
                         }
                     );

--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -256,9 +256,11 @@ Checks if the user has the rights to update this record.
                             my ($rec, $errors) = @_;
                             librecat->log->errorf(
                                 "%s not a valid publication %s",
-                                $rec->{_id} // 'NEW', $errors);
+                                $rec->{_id} // 'NEW', [map { $_->{message} } @$errors]);
                             $is_error_record = 1;
-                            $error_messages  = $errors;
+                            $error_messages  = [ map {
+                                localize( @{ $_->{i18n} } );
+                            } @$errors ];
                         }
                     );
                 }

--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -419,11 +419,11 @@ sub io_from_plack_writer {
 }
 
 sub localize {
-    my ($self, $str) = @_;
+    my $self = shift;
     state $locales = {};
     my $loc = $self->locale;
     my $i18n = $locales->{$loc} //= LibreCat::I18N->new(locale => $loc);
-    $i18n->localize($str);
+    $i18n->localize(@_);
 }
 sub uri_for_locale {
     my ( $self, $locale ) = @_;

--- a/lib/LibreCat/Audit.pm
+++ b/lib/LibreCat/Audit.pm
@@ -8,6 +8,12 @@ use namespace::clean;
 
 extends "LibreCat::Validator::JSONSchema";
 
+has namespace => (
+    is => "ro",
+    default => sub { "validator.audit.errors" },
+    init_arg => undef
+);
+
 has schema => (
     is => "ro",
     lazy => 1,

--- a/lib/LibreCat/Cmd/department.pm
+++ b/lib/LibreCat/Cmd/department.pm
@@ -3,7 +3,6 @@ package LibreCat::Cmd::department;
 use Catmandu::Sane;
 use LibreCat qw(department);
 use Carp;
-use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -285,16 +284,6 @@ sub _get {
     return $data ? 0 : 2;
 }
 
-sub _localize {
-
-    state $i18n = LibreCat::I18N->new( locale => "en" );
-
-    my $self = shift;
-
-    $i18n->localize( @_ );
-
-}
-
 sub _add {
     my ($self, $file) = @_;
 
@@ -309,7 +298,7 @@ sub _add {
             my ($rec, $errors) = @_;
             say STDERR join("\n",
                 $rec->{_id}, "ERROR: not a valid department",map {
-                    $self->_localize( @{ $_->{i18n} } )
+                    $_->localize();
                 } @$errors);
             $ret = 2;
         },
@@ -355,7 +344,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: " . $self->_localize( @{ $err->{i18n} } );
+                        say STDERR "ERROR $id: " . $err->localize();
                     }
                 }
                 else {

--- a/lib/LibreCat/Cmd/department.pm
+++ b/lib/LibreCat/Cmd/department.pm
@@ -3,6 +3,7 @@ package LibreCat::Cmd::department;
 use Catmandu::Sane;
 use LibreCat qw(department);
 use Carp;
+use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -284,6 +285,16 @@ sub _get {
     return $data ? 0 : 2;
 }
 
+sub _localize {
+
+    state $i18n = LibreCat::I18N->new( locale => "en" );
+
+    my $self = shift;
+
+    $i18n->localize( @_ );
+
+}
+
 sub _add {
     my ($self, $file) = @_;
 
@@ -297,7 +308,9 @@ sub _add {
         on_validation_error => sub {
             my ($rec, $errors) = @_;
             say STDERR join("\n",
-                $rec->{_id}, "ERROR: not a valid department", @$errors);
+                $rec->{_id}, "ERROR: not a valid department",map {
+                    $self->_localize( @{ $_->{i18n} } )
+                } @$errors);
             $ret = 2;
         },
         on_success => sub {
@@ -342,7 +355,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: $err";
+                        say STDERR "ERROR $id: " . $self->_localize( @{ $err->{i18n} } );
                     }
                 }
                 else {

--- a/lib/LibreCat/Cmd/project.pm
+++ b/lib/LibreCat/Cmd/project.pm
@@ -3,6 +3,7 @@ package LibreCat::Cmd::project;
 use Catmandu::Sane;
 use LibreCat qw(project);
 use Carp;
+use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -182,6 +183,16 @@ sub _get {
     return $data ? 0 : 2;
 }
 
+sub _localize {
+
+    state $i18n = LibreCat::I18N->new( locale => "en" );
+
+    my $self = shift;
+
+    $i18n->localize( @_ );
+
+}
+
 sub _add {
     my ($self, $file) = @_;
 
@@ -195,7 +206,9 @@ sub _add {
         on_validation_error => sub {
             my ($rec, $errors) = @_;
             say STDERR join("\n",
-                $rec->{_id}, "ERROR: not a valid project", @$errors);
+                $rec->{_id}, "ERROR: not a valid project",map {
+                    $self->_localize( @{ $_->{i18n} } )
+                } @$errors);
             $ret = 2;
         },
         on_success => sub {
@@ -240,7 +253,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: $err";
+                        say STDERR "ERROR $id: " . $self->_localize( @{ $err->{i18n} } );
                     }
                 }
                 else {

--- a/lib/LibreCat/Cmd/project.pm
+++ b/lib/LibreCat/Cmd/project.pm
@@ -3,7 +3,6 @@ package LibreCat::Cmd::project;
 use Catmandu::Sane;
 use LibreCat qw(project);
 use Carp;
-use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -183,16 +182,6 @@ sub _get {
     return $data ? 0 : 2;
 }
 
-sub _localize {
-
-    state $i18n = LibreCat::I18N->new( locale => "en" );
-
-    my $self = shift;
-
-    $i18n->localize( @_ );
-
-}
-
 sub _add {
     my ($self, $file) = @_;
 
@@ -207,7 +196,7 @@ sub _add {
             my ($rec, $errors) = @_;
             say STDERR join("\n",
                 $rec->{_id}, "ERROR: not a valid project",map {
-                    $self->_localize( @{ $_->{i18n} } )
+                    $_->localize();
                 } @$errors);
             $ret = 2;
         },
@@ -253,7 +242,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: " . $self->_localize( @{ $err->{i18n} } );
+                        say STDERR "ERROR $id: " . $err->localize();
                     }
                 }
                 else {

--- a/lib/LibreCat/Cmd/publication.pm
+++ b/lib/LibreCat/Cmd/publication.pm
@@ -9,7 +9,6 @@ use LibreCat::App::Catalogue::Controller::File;
 use Path::Tiny;
 use Carp;
 use LibreCat::Audit;
-use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -313,16 +312,6 @@ sub _get {
     return $rec ? 0 : 2;
 }
 
-sub _localize {
-
-    state $i18n = LibreCat::I18N->new( locale => "en" );
-
-    my $self = shift;
-
-    $i18n->localize( @_ );
-
-}
-
 sub _add {
     my ($self, $file, $out_file) = @_;
 
@@ -348,7 +337,7 @@ sub _add {
             my ($rec, $errors) = @_;
 
             my @t_errors = map {
-                $self->_localize( @{ $_->{i18n} } )
+                $_->localize();
             } @$errors;
 
             $self->log->errorf("%s not a valid publication %s", $rec->{_id}, \@t_errors);
@@ -441,7 +430,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: " . $self->_localize( @{ $err->{i18n} } );
+                        say STDERR "ERROR $id: " . $err->localize();
                     }
                 }
                 else {
@@ -633,7 +622,7 @@ sub _checksum_id {
                 my ($rec, $e) = @_;
 
                 my @t_errors = map {
-                    $self->_localize( @{ $_->{i18n} } )
+                    $_->localize();
                 } @$e;
 
                 $self->log->errorf("%s not a valid publication %s", $rec->{_id}, \@t_errors);

--- a/lib/LibreCat/Cmd/research_group.pm
+++ b/lib/LibreCat/Cmd/research_group.pm
@@ -3,6 +3,7 @@ package LibreCat::Cmd::research_group;
 use Catmandu::Sane;
 use LibreCat qw(research_group);
 use Carp;
+use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -182,6 +183,16 @@ sub _get {
     return $data ? 0 : 2;
 }
 
+sub _localize {
+
+    state $i18n = LibreCat::I18N->new( locale => "en" );
+
+    my $self = shift;
+
+    $i18n->localize( @_ );
+
+}
+
 sub _add {
     my ($self, $file) = @_;
 
@@ -195,7 +206,9 @@ sub _add {
         on_validation_error => sub {
             my ($rec, $errors) = @_;
             say STDERR join("\n",
-                $rec->{_id}, "ERROR: not a valid research_group", @$errors);
+                $rec->{_id}, "ERROR: not a valid research_group",map {
+                    $self->_localize( @{ $_->{i18n} } )
+                } @$errors);
             $ret = 2;
         },
         on_success => sub {
@@ -240,7 +253,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: $err";
+                        say STDERR "ERROR $id: " . $self->_localize( @{ $err->{i18n} } );
                     }
                 }
                 else {

--- a/lib/LibreCat/Cmd/research_group.pm
+++ b/lib/LibreCat/Cmd/research_group.pm
@@ -3,7 +3,6 @@ package LibreCat::Cmd::research_group;
 use Catmandu::Sane;
 use LibreCat qw(research_group);
 use Carp;
-use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -183,16 +182,6 @@ sub _get {
     return $data ? 0 : 2;
 }
 
-sub _localize {
-
-    state $i18n = LibreCat::I18N->new( locale => "en" );
-
-    my $self = shift;
-
-    $i18n->localize( @_ );
-
-}
-
 sub _add {
     my ($self, $file) = @_;
 
@@ -207,7 +196,7 @@ sub _add {
             my ($rec, $errors) = @_;
             say STDERR join("\n",
                 $rec->{_id}, "ERROR: not a valid research_group",map {
-                    $self->_localize( @{ $_->{i18n} } )
+                    $_->localize();
                 } @$errors);
             $ret = 2;
         },
@@ -253,7 +242,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: " . $self->_localize( @{ $err->{i18n} } );
+                        say STDERR "ERROR $id: " . $err->localize();
                     }
                 }
                 else {

--- a/lib/LibreCat/Cmd/user.pm
+++ b/lib/LibreCat/Cmd/user.pm
@@ -4,7 +4,6 @@ use Catmandu::Sane;
 use LibreCat qw(user);
 use App::bmkpasswd qw(passwdcmp mkpasswd);
 use Carp;
-use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -190,16 +189,6 @@ sub _get {
     return $data ? 0 : 2;
 }
 
-sub _localize {
-
-    state $i18n = LibreCat::I18N->new( locale => "en" );
-
-    my $self = shift;
-
-    $i18n->localize( @_ );
-
-}
-
 sub _add {
     my ($self, $file) = @_;
 
@@ -222,7 +211,7 @@ sub _add {
             my ($rec, $errors) = @_;
             say STDERR
                 join("\n", $rec->{_id}, "ERROR: not a valid user", map {
-                    $self->_localize( @{ $_->{i18n} } )
+                    $_->localize();
                 } @$errors);
             $ret = 2;
         },
@@ -268,7 +257,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: ".$self->_localize( @{ $err->{i18n} } );
+                        say STDERR "ERROR $id: ".$err->localize();
                     }
                 }
                 else {

--- a/lib/LibreCat/Cmd/user.pm
+++ b/lib/LibreCat/Cmd/user.pm
@@ -4,6 +4,7 @@ use Catmandu::Sane;
 use LibreCat qw(user);
 use App::bmkpasswd qw(passwdcmp mkpasswd);
 use Carp;
+use LibreCat::I18N;
 use parent qw(LibreCat::Cmd);
 
 sub description {
@@ -189,6 +190,16 @@ sub _get {
     return $data ? 0 : 2;
 }
 
+sub _localize {
+
+    state $i18n = LibreCat::I18N->new( locale => "en" );
+
+    my $self = shift;
+
+    $i18n->localize( @_ );
+
+}
+
 sub _add {
     my ($self, $file) = @_;
 
@@ -210,7 +221,9 @@ sub _add {
         on_validation_error => sub {
             my ($rec, $errors) = @_;
             say STDERR
-                join("\n", $rec->{_id}, "ERROR: not a valid user", @$errors);
+                join("\n", $rec->{_id}, "ERROR: not a valid user", map {
+                    $self->_localize( @{ $_->{i18n} } )
+                } @$errors);
             $ret = 2;
         },
         on_success => sub {
@@ -255,7 +268,7 @@ sub _valid {
                 my $id     = $item->{_id} // '';
                 if ($errors) {
                     for my $err (@$errors) {
-                        say STDERR "ERROR $id: $err";
+                        say STDERR "ERROR $id: ".$self->_localize( @{ $err->{i18n} } );
                     }
                 }
                 else {

--- a/lib/LibreCat/Hook/audit_message.pm
+++ b/lib/LibreCat/Hook/audit_message.pm
@@ -61,8 +61,9 @@ sub fix {
         $self->audit->add( $r )
     ){
 
+        my $current_locale = h->locale();
         h->log->error( "validation audit failed: ".join(",",map {
-            h->localize( @{ $_->{i18n}  } );
+            $_->localize( $current_locale );
         } @{ $self->audit()->last_errors() }). ". Record: " . to_yaml($r) );
 
     }

--- a/lib/LibreCat/Hook/audit_message.pm
+++ b/lib/LibreCat/Hook/audit_message.pm
@@ -61,7 +61,9 @@ sub fix {
         $self->audit->add( $r )
     ){
 
-        h->log->error( "validation audit failed: ".join(",",@{ $self->audit()->last_errors() }). ". Record: " . to_yaml($r) );
+        h->log->error( "validation audit failed: ".join(",",map {
+            h->localize( @{ $_->{i18n}  } );
+        } @{ $self->audit()->last_errors() }). ". Record: " . to_yaml($r) );
 
     }
 

--- a/lib/LibreCat/Validation/Error.pm
+++ b/lib/LibreCat/Validation/Error.pm
@@ -1,0 +1,132 @@
+package LibreCat::Validation::Error;
+
+use Catmandu::Sane;
+use Catmandu::Util qw(:is :check);
+use Catmandu;
+use Catmandu::Error;
+use Moo;
+use LibreCat::I18N;
+use overload q("") => \&to_string, bool => sub {1}, fallback => 1;
+
+has code => (
+    is => "ro",
+    isa => sub { check_string($_[0]); },
+    required => 1
+);
+
+has property => (
+    is => "ro",
+    isa => sub { check_string($_[0]); },
+    required => 1
+);
+
+has field => (
+    is => "ro",
+    isa => sub { check_string($_[0]); },
+    required => 1
+);
+
+has validator => (
+    is => "ro",
+    isa => sub { check_string($_[0]); },
+    required => 1
+);
+
+has i18n => (
+    is => "ro",
+    isa => sub { check_array_ref($_[0]); },
+    required => 1
+);
+
+sub localize {
+
+    my( $self, $locale ) = @_;
+
+    $locale //= Catmandu->config->{default_lang} || Catmandu::Error->throw(
+        "no locale given and no default_lang configured"
+    );
+
+    $self->{_i18n} //= {};
+    $self->{_i18n}->{$locale} //= LibreCat::I18N->new( locale => $locale );
+
+    $self->{_i18n}->{$locale}->localize(
+        @{ $self->i18n() }
+    );
+}
+
+sub to_string {
+
+    $_[0]->localize();
+
+}
+
+1;
+
+__END__
+
+=pod
+
+=head1 NAME
+
+LibreCat::Validation::Error - class for model validation errors
+
+=head1 SYNOPSIS
+
+    package MyPackage;
+
+    use Catmandu::Sane;
+    use LibreCat::Validator::JSONSchema;
+    use LibreCat::App::Helper;
+
+    my $publication_validator =
+        LibreCat::Validator::JSONSchema->new(schema => h->config->{schemas}{publication});
+
+    unless ($publication_validator->is_valid($rec)) {
+
+        for my $error( @{ $publication_validator->last_errors } ){
+
+            say "error code: " . $error->code;
+            say "localized error message: " . $error->localize("en");
+            say "json path to affected field: " . $error->property;
+            say "short name for affected field: " . $error->field;
+
+        }
+
+    }
+
+=head1 METHODS
+
+=head2 new( code => $code, property => $json_path, field => $field_name, i18n => $array_ref, validator => $package_name )
+
+=head2 code()
+
+returns error code
+
+=head2 property()
+
+returns json path to attribute that contains the invalid value.
+
+e.g. "file.1.access_level"
+
+=head2 field()
+
+returns field name for attribute that contains the invalid value.
+
+e.g. "file.access_level"
+
+=head2 i18n()
+
+returns array ref of arguments for localisation
+
+e.g. ["validator.jsonschema.errors.integer.maximum",4,2]
+
+=head2 validator()
+
+returns package name that generated this object
+
+=head1 SEE ALSO
+
+L<LibreCat>, L<Librecat::Validator>, L<Catmandu::Validator>,
+L<Catmandu::Validator::JSONSchema>, L<config/schemas.yml>
+
+=cut

--- a/lib/LibreCat/Validator.pm
+++ b/lib/LibreCat/Validator.pm
@@ -1,11 +1,18 @@
 package LibreCat::Validator;
 
 use Catmandu::Sane;
+use Catmandu::Util qw(check_string);
 use Moo::Role;
 
 with 'Catmandu::Validator';
 
 has whitelist => (is => 'lazy');
+
+has namespace => (
+    is => "ro",
+    required => 1,
+    isa => sub { check_string($_[0]); }
+);
 
 sub _build_whitelist {
     [];
@@ -32,6 +39,54 @@ LibreCat::Validator - a base class for validators
     sub _build_whitelist {
         return ["author", "title", "year"];
     }
+
+=head1 namespace
+
+    namespace, used to prefix I18N codes
+
+=head1 errors
+
+Each error must be an object that has the following keys:
+
+    * code:
+
+        * type: string
+
+        * description: error code
+
+    * property:
+
+        * type: string
+
+        * description: json path to the thing that caused the error
+
+        e.g. file.0.access_level
+
+    * field:
+
+        * type: string
+
+        * description: field name. Simplified version of property, so without index in its path.
+
+        e.g. file.access_level
+
+    * i18n:
+
+        * type: array reference
+
+        * description: list of arguments for localisation, typically the i18n key, followed by its arguments.
+
+    * message:
+
+        * type: string
+
+        * description: internal description of the error
+
+    * validator:
+
+        * type: string
+
+        * description: name of the validator.
 
 =head1 SEE ALSO
 

--- a/lib/LibreCat/Validator.pm
+++ b/lib/LibreCat/Validator.pm
@@ -40,53 +40,20 @@ LibreCat::Validator - a base class for validators
         return ["author", "title", "year"];
     }
 
+    package main;
+
+    my $validator = MyValidator->new(
+        namespace => "validator.myvalidator.errors",
+        schema => { type => "object" }
+    );
+
 =head1 namespace
 
     namespace, used to prefix I18N codes
 
 =head1 errors
 
-Each error must be an object that has the following keys:
-
-    * code:
-
-        * type: string
-
-        * description: error code
-
-    * property:
-
-        * type: string
-
-        * description: json path to the thing that caused the error
-
-        e.g. file.0.access_level
-
-    * field:
-
-        * type: string
-
-        * description: field name. Simplified version of property, so without index in its path.
-
-        e.g. file.access_level
-
-    * i18n:
-
-        * type: array reference
-
-        * description: list of arguments for localisation, typically the i18n key, followed by its arguments.
-
-    * message:
-
-        * type: string
-
-        * description: internal description of the error
-
-    * validator:
-
-        * type: string
-
-        * description: name of the validator.
+Each error must be an object of package L<LibreCat::Validation::Error>
 
 =head1 SEE ALSO
 

--- a/lib/LibreCat/Validator/JSONSchema.pm
+++ b/lib/LibreCat/Validator/JSONSchema.pm
@@ -1,6 +1,7 @@
 package LibreCat::Validator::JSONSchema;
 
 use Catmandu::Sane;
+use Catmandu::Util qw(is_natural);
 use Moo;
 use namespace::clean;
 
@@ -14,15 +15,54 @@ sub _build_whitelist {
     [keys %$properties];
 }
 
+sub _t_error {
+
+    my($self,$error) = @_;
+
+    my $prop = $error->{property};
+
+    #/file/0/access_level => file.0.access_level
+    $prop    =~ s/^\///o;
+    $prop    = join( ".",split( "/",$prop ) );
+    $prop    = "." if $prop eq "";
+
+    #/file/0/access_level => file.access_level
+    my $f    = join( ".",grep { !is_natural($_) } split( /\./,$prop ) );
+    $f       = "." if $f eq "";
+
+    my @details = @{ $error->{details} };
+
+    my $d_key1  = shift(@details);
+    my $d_key2  = shift(@details);
+    my @d_args  = @details;
+
+    #code
+    my $code = "${d_key1}.${d_key2}";
+
+    #i18n
+    my $i18n = [ $self->namespace() . "." . $code, @d_args ];
+
+    +{
+        #error code
+        code      => $code,
+        #list of arguments for localisation
+        i18n      => $i18n,
+        #json path to the cause of the error
+        property  => $prop,
+        #shorter field name
+        field     => $f,
+        #name of validator
+        validator => "jsonschema",
+        message   => $error->{message}
+    };
+}
+
 around last_errors => sub {
     my $orig   = shift;
-    my $errors = $orig->(@_) // return;
+    my $self   = shift;
+    my $errors = $orig->($self,@_) // return;
     [
-      map {
-        sprintf "%s: %s"
-            , $_->{property} // '<null>'
-            , $_->{message}  // '<null>'
-      } @$errors
+      map { $self->_t_error($_) } @$errors
     ];
 };
 

--- a/t/LibreCat/Cmd/publication.t
+++ b/t/LibreCat/Cmd/publication.t
@@ -62,7 +62,7 @@ note("testing valid");
             ['publication', 'valid', 't/records/invalid-publication.yml']);
     ok $result->error, 'invalid publication';
 
-    like $result->stderr, qr/type: Missing property/, 'missing title';
+    like $result->stderr, qr/type is required/, 'missing title';
 
     my $result2 = test_app(qq|LibreCat::CLI| =>
             ['publication', 'valid', 't/records/valid-publication.yml']);

--- a/t/LibreCat/Model.t
+++ b/t/LibreCat/Model.t
@@ -31,7 +31,7 @@ require_ok $pkg;
 my $m = T::Model->new(
     bag        => Catmandu->store('main')->bag('model_test'),
     search_bag => Catmandu->store('search')->bag('model_test'),
-    validator  => T::Validator->new,
+    validator  => T::Validator->new(namespace => "validator.t.errors"),
 );
 
 ok $m->does('LibreCat::Model');

--- a/t/LibreCat/Model/User.t
+++ b/t/LibreCat/Model/User.t
@@ -19,7 +19,8 @@ my $user = $pkg->new(
     bag        => Catmandu->store('main')->bag('user'),
     search_bag => Catmandu->store('search')->bag('user'),
     validator  => LibreCat::Validator::JSONSchema->new(
-        schema => Catmandu->config->{schemas}{user}
+        schema => Catmandu->config->{schemas}{user},
+        namespace => "validator.jsonschema.errors"
     )
 );
 

--- a/t/LibreCat/Validation/Error.t
+++ b/t/LibreCat/Validation/Error.t
@@ -1,0 +1,50 @@
+use Catmandu::Sane;
+use LibreCat -self => -load => {layer_paths => [qw(t/layer)]};
+use Test::More;
+use Test::Exception;
+use warnings FATAL => 'all';
+
+my $pkg;
+
+BEGIN {
+    $pkg = 'LibreCat::Validation::Error';
+    use_ok $pkg;
+}
+
+require_ok $pkg;
+
+dies_ok sub {
+    $pkg->new();
+};
+
+dies_ok sub {
+    $pkg->new( code => "error" );
+};
+
+dies_ok sub {
+    $pkg->new( code => "error", property => "_id" );
+};
+
+dies_ok sub {
+    $pkg->new( code => "error", property => "_id", field => "_id" );
+};
+
+dies_ok sub {
+    $pkg->new( code => "error", property => "_id", field => "_id", i18n => ["errors.string.type"] );
+};
+
+my $error;
+
+lives_ok sub {
+    $error = $pkg->new( code => "error", property => "_id", field => "_id", i18n => ["errors.string.type","array"], validator => "LibreCat::Validator::JSONSchema" );
+};
+
+LibreCat->config->{locale}->{en}->{errors}->{string}->{type} = "must be a string, got [_1]";
+
+my $l_message = "must be a string, got array";
+is $error->localize(), $l_message, "default lang is en";
+is $error, $l_message, "overloaded object returns localized error message in default language";
+is $error, $error->to_string(),"overloaded object returns localized error message using to_string";
+is $error->localize("en"), $l_message;
+
+done_testing;

--- a/t/LibreCat/Validator.t
+++ b/t/LibreCat/Validator.t
@@ -23,7 +23,7 @@ require_ok $pkg;
 }
 
 {
-    my $x = T::Validator->new();
+    my $x = T::Validator->new(namespace => "validator.t.errors");
     can_ok $x, $_ for qw(whitelist validate_data last_errors);
 
     is_deeply $x->whitelist, [], "default white list";

--- a/t/LibreCat/Validator/JSONSchema.t
+++ b/t/LibreCat/Validator/JSONSchema.t
@@ -16,6 +16,7 @@ require_ok $pkg;
 note("Validate user");
 {
     my $x = LibreCat::Validator::JSONSchema->new(
+        namespace => "validator.jsonschema.errors",
         schema => librecat->config->{schemas}{user});
 
     ok $x , 'got a user validator';
@@ -48,6 +49,7 @@ note("Validate user");
 note("Validate research_group");
 {
     my $x = LibreCat::Validator::JSONSchema->new(
+        namespace => "validator.jsonschema.errors",
         schema => librecat->config->{schemas}{research_group});
 
     ok $x , 'got a research_group validator';
@@ -73,6 +75,7 @@ note("Validate research_group");
 note("Validate department");
 {
     my $x = LibreCat::Validator::JSONSchema->new(
+        namespace => "validator.jsonschema.errors",
         schema => librecat->config->{schemas}{department});
 
     ok $x , 'got a department validator';
@@ -104,6 +107,7 @@ note("Validate department");
 note("Validate project");
 {
     my $x = LibreCat::Validator::JSONSchema->new(
+        namespace => "validator.jsonschema.errors",
         schema => librecat->config->{schemas}{project});
 
     ok $x , 'got a project validator';
@@ -128,6 +132,7 @@ note("Validate project");
 note("Validate publiction");
 {
     my $x = LibreCat::Validator::JSONSchema->new(
+        namespace => "validator.jsonschema.errors",
         schema => librecat->config->{schemas}{publication});
 
     ok $x , 'got a publication validator';
@@ -159,6 +164,7 @@ note("Validate publiction");
 
 {
     my $x = LibreCat::Validator::JSONSchema->new(
+        namespace => "validator.jsonschema.errors",
         schema => {unknown_schema => 1});
 
     ok $x , 'define unkown validator';

--- a/t/LibreCat/Validator/Mock.t
+++ b/t/LibreCat/Validator/Mock.t
@@ -1,0 +1,76 @@
+use Catmandu::Sane;
+use LibreCat -self => -load => {layer_paths => [qw(t/layer)]};
+use Test::More;
+use Test::Exception;
+use warnings FATAL => 'all';
+
+{
+
+    package LibreCat::Validator::Mock;
+    use Moo;
+    extends "LibreCat::Validator::JSONSchema";
+
+    around validate_data => sub {
+        my ($orig, $self,@args) = @_;
+        my $errors = $orig->($self,@args);
+
+        my $record = shift( @args );
+
+        if( exists( $record->{user_id} ) ){
+
+            my $user = LibreCat->instance->model("user")->get( $record->{user_id} );
+
+            unless( $user ) {
+
+                push @$errors, LibreCat::Validation::Error->new(
+                    code      => "user.not_found",
+                    i18n      => [
+                        "validator.mock.errors.user.not_found","user_id",$record->{user_id}
+                    ],
+                    property  => "user_id",
+                    field     => "user_id",
+                    validator => ref($self)
+                );
+
+            }
+
+        }
+
+
+        $errors;
+    };
+
+}
+
+LibreCat->config->{locale}{en}{validator}{mock}{errors}{user}{not_found} = "user with identifier [_2] could not be found";
+LibreCat->config->{models}{publication}{validator} = {
+    package => "LibreCat::Validator::Mock",
+    options => {
+        schema => "publication"
+    }
+};
+
+my $validator;
+
+lives_ok(sub{
+
+    $validator = LibreCat->instance->model("publication")->validator();
+
+});
+
+my $record = {
+    _id => "a",
+    title => "a",
+    type  => "book",
+    status => "new"
+};
+
+ok $validator->is_valid($record);
+
+$record->{user_id} = "this_user_should_not_exist";
+
+ok ! $validator->is_valid($record);
+
+is $validator->last_errors()->[0]->localize("en"), "user with identifier this_user_should_not_exist could not be found";
+
+done_testing;


### PR DESCRIPTION
Changed:

* change the validator used per model:
```
models:
  publication:
    validator:
      package: LibreCat::Validator::T
      options:
       #LibreCat uses this option to add the full schema object as an argument
        schema: publication
        namespace: "validator.t.errors" 
```

* Error format: `LibreCat::Validation::Error` instead of just an object with "field" and (already translated) "message":

  * `code`: error code
  * `property`: json path to field that caused the error (e.g. file.0.access_level)
  * `field`: short field name. (e.g. "file.access_level")
  * `i18n`: array reference of arguments for localisation.
  * `localize`: method that translates error message. Accepts language code, or uses default language.

* Every `LibreCat::Validator` requires an argument called `namespace` that is used to prefix all error messages to be translated.

To be discussed.

Questions:

* include field name in I18N argument list ( e.g. "field [_1] has incorrect value [_2]" ) ?