### PR TITLE
separate use route params from query params

### DIFF
--- a/lib/LibreCat/App.pm
+++ b/lib/LibreCat/App.pm
@@ -74,6 +74,17 @@ hook before => sub {
     }
 };
 
+hook before_template_render => sub {
+
+    my $tokens = $_[0];
+
+    #params in TT is hash resulted from call to "params()"
+    $tokens->{params_query} = params("query");
+    $tokens->{params_body} = params("body");
+    $tokens->{params_route} = params("route");
+
+};
+
 sub _login_route {
     my $conf = shift;
     sub {

--- a/views/admin/account.tt
+++ b/views/admin/account.tt
@@ -1,7 +1,6 @@
-[% qp = request.params.hash %]
-[% qp.delete('splat') %]
+[%- qp = params_query -%]
 [% lang = h.locale() -%]
-[% backend = request.path_info.match('librecat') ? 1 : 0 %]
+[%- backend = 1 -%]
 
 [% INCLUDE header.tt %]
 
@@ -21,7 +20,7 @@
 	<div class="col-md-5">
 	  <label for="id_q"><span class="fa fa-search"></span> Search by name or ID</label>
 	  <div class="input-group">
-	    <input type="text" class="form-control" name="q" id="id_q" placeholder="Einstein, A" value="[% qp.q %]">
+	    <input type="text" class="form-control" name="q" id="id_q" placeholder="Einstein, A" value="[% qp.q | html %]">
 	    <span class="input-group-btn">
 	      <button type="submit" class="btn btn-default"><i><span class="fa fa-search"></span> </i>Search</button>
 	    </span>
@@ -31,7 +30,7 @@
     </form>
 
     [%- IF error %]
-      <p class="text-danger">[% error %] <a href="[% uri_base %]/librecat/admin/account/edit/[% qp.id %]"><span class="fa fa-pencil fw"></span>Edit</a></p>
+      <p class="text-danger">[% error %] <a href="[% uri_base %]/librecat/admin/account/edit/[% qp.id | uri %]"><span class="fa fa-pencil fw"></span>Edit</a></p>
     [%- END %]
 
     <div class="row col-md-12 margin-top1 margin-bottom2">

--- a/views/admin/project.tt
+++ b/views/admin/project.tt
@@ -1,8 +1,7 @@
-[% qp = request.params.hash %]
-[% qp.delete('splat') %]
+[%- qp = params_query -%]
 [% lang = h.locale() -%]
 [% lf = h.config.locale.$lang -%]
-[% backend = request.path_info.match('librecat') ? 1 : 0 %]
+[%- backend = 1 -%]
 
 [% INCLUDE header.tt %]
 
@@ -23,7 +22,7 @@
 	<div class="col-md-5">
 	  <label for="id_q">Search Projects</label>
 	  <div class="input-group">
-	    <input type="text" class="form-control" name="q" id="id_q" value="[% qp.q %]">
+	    <input type="text" class="form-control" name="q" id="id_q" value="[% qp.q | html %]">
 	    <span class="input-group-btn">
 	      <button type="submit" class="btn btn-default"><i><span class="fa fa-search"></span> </i>Search</button>
 	    </span>
@@ -50,7 +49,7 @@
     <dl class="hitlist">
     [%- FOREACH p IN hits %]
 	<dt>
-	<a href="[% uri_base %]/librecat/admin/project/edit/[% p._id %]"><span class="fa fa-pencil fw"></span>[% p.name %]</a>
+	<a href="[% uri_base %]/librecat/admin/project/edit/[% p._id | uri %]"><span class="fa fa-pencil fw"></span>[% p.name %]</a>
     | <span class="text-muted">ID: [% p._id %]</span>
     </dt>
 	<dd>

--- a/views/admin/research_group.tt
+++ b/views/admin/research_group.tt
@@ -1,8 +1,7 @@
-[% qp = request.params.hash %]
-[% qp.delete('splat') %]
+[%- qp = params_query -%]
 [% lang = h.locale() -%]
 [% lf = h.config.locale.$lang -%]
-[% backend = request.path_info.match('librecat') ? 1 : 0 %]
+[%- backend = 1 -%]
 
 [% INCLUDE header.tt %]
 
@@ -23,7 +22,7 @@
 	<div class="col-md-5">
 	  <label for="id_q">Search Research Groups</label>
 	  <div class="input-group">
-	    <input type="text" class="form-control" name="q" id="id_q" value="[% qp.q %]">
+	    <input type="text" class="form-control" name="q" id="id_q" value="[% qp.q | html %]">
 	    <span class="input-group-btn">
 	      <button type="submit" class="btn btn-default"><i><span class="fa fa-search"></span> </i>Search</button>
 	    </span>

--- a/views/backend/user_settings.tt
+++ b/views/backend/user_settings.tt
@@ -8,7 +8,7 @@
   [%- IF thisPerson.super_admin OR thisPerson.reviewer OR thisPerson.project_reviewer OR thisPerson.data_manager OR thisPerson.delegate %]
   <div class="row innerrow">
     <div class="col-md-11">
-      <h5>[% h.loc("header.role_label") %]: <em><strong>[% lf.header.role.item(session.role) %]</strong></em></h5>
+      <h5>[% h.loc("header.role_label") %]: <em><strong>[% h.loc("header.role." _ session.role) %]</strong></em></h5>
       ([% h.loc("header.role_change") %]
       [%- IF session.role != "user" %]
       <a href="[% uri_base %]/librecat/change_role/user">[% h.loc("header.role.user") %]</a>
@@ -20,7 +20,7 @@
 	  | <a href="[% uri_base %]/librecat/change_role/reviewer">[% h.loc("header.role.reviewer") %]</a>
 	  [%- END %]
       [%- IF thisPerson.project_reviewer AND session.role != "project_reviewer" %]
-      | <a href="[% uri_base %]/librecat/change_role/project_reviewer">[% lf.header.role.project_reviewer %]</a>
+      | <a href="[% uri_base %]/librecat/change_role/project_reviewer">[% h.loc("header.role.project_reviewer") %]</a>
       [%- END %]
       [%- IF thisPerson.data_manager AND session.role != "data_manager" %]
 	  | <a href="[% uri_base %]/librecat/change_role/data_manager">[% h.loc("header.role.data_manager") %]</a>

--- a/views/department/list.tt
+++ b/views/department/list.tt
@@ -1,8 +1,7 @@
-[%- qp = request.params.hash %]
-[%- qp.delete('splat') %]
+[%- qp = params_query %]
 [% PROCESS header.tt %]
 <!-- BEGIN department/list.tt -->
-<span id="language_id" class="hidden">[% lang %]</span>
+<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/department/list.tt
+++ b/views/department/list.tt
@@ -1,7 +1,6 @@
 [%- qp = params_query %]
 [% PROCESS header.tt %]
 <!-- BEGIN department/list.tt -->
-<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/embed/iframe.tt
+++ b/views/embed/iframe.tt
@@ -1,5 +1,4 @@
-[% qp = request.params.hash -%]
-[% qp.delete('splat') -%]
+[%- qp = params_query -%]
 [% lang = h.locale() -%]
 [% style = qp.style ? qp.style : h.config.citation.csl.default_style -%]
 <!DOCTYPE html>

--- a/views/embed/javascript.tt
+++ b/views/embed/javascript.tt
@@ -1,5 +1,5 @@
 <!-- BEGIN embed/javascript.tt -->
-[% qp = request.params.hash -%]
+[%- qp = params_query -%]
 [% lang = h.locale() -%]
 document.write ('<ul[% IF qp.listyle %] style="[% qp.listyle %]"[% END %]>') ;
 [%- style = qp.style %]

--- a/views/header.tt
+++ b/views/header.tt
@@ -2,6 +2,7 @@
 <html lang="[% h.loc('language_code') %]">
 [% lang = h.locale() -%]
 [% lf = h.config.locale.$lang -%]
+[% qp = params_query %]
 [% path_info = request.path_info -%]
 
 <!-- BEGIN header.tt -->
@@ -44,13 +45,13 @@
     [% personid = path_info.search('person/(\d{1,})') -%]
     [% query = qp.q | replace('"', '&quot;') -%]
     [%- IF path_info.match("person/") %]
-      [%- qp.q = "person%2D$personid"%]
-      <link rel="alternate" type="application/rss+xml" href="[% h.uri_for('/feed/daily', qp) %]" title="[% thisPerson.first_name | html %] [% thisPerson.last_name | html %]'s Publication (today)">
-      <link rel="alternate" type="application/rss+xml" href="[% h.uri_for('/feed/weekly', qp) %]" title="[% thisPerson.first_name | html %] [% thisPerson.last_name | html %]'s Publication (last week)">
-      <link rel="alternate" type="application/rss+xml" href="[% h.uri_for('/feed/monthly', qp) %]" title="[% thisPerson.first_name | html %] [% thisPerson.last_name | html %]'s Publication (last month)">
+      [%- query = "person%2D$personid"%]
+      <link rel="alternate" type="application/rss+xml" href="[% h.uri_for('/feed/daily', q = query) %]" title="[% thisPerson.first_name | html %] [% thisPerson.last_name | html %]'s Publication (today)">
+      <link rel="alternate" type="application/rss+xml" href="[% h.uri_for('/feed/weekly', q = query) %]" title="[% thisPerson.first_name | html %] [% thisPerson.last_name | html %]'s Publication (last week)">
+      <link rel="alternate" type="application/rss+xml" href="[% h.uri_for('/feed/monthly', q = query) %]" title="[% thisPerson.first_name | html %] [% thisPerson.last_name | html %]'s Publication (last month)">
     [%- ELSIF path_info.match("text") %]
       [%- qp.q = query %]
-      <link rel="alternate" type="application/rss+xml" href="[% h.uri_for('/feed/monthly', qp) %]" title="Publications last month">
+      <link rel="alternate" type="application/rss+xml" href="[% h.uri_for('/feed/monthly', q = query) %]" title="Publications last month">
     [%- END %]
     [% UNLESS backend %]
     <meta name="robots" content="index,follow,noimageindex" />

--- a/views/hits.tt
+++ b/views/hits.tt
@@ -16,7 +16,7 @@
 
 [%- IF !backend AND total AND total > 1 %]
 [%- IF request.path_info.match("/person") %]
-[%- all_marked = h.all_marked(request.params) %]
+[%- all_marked = h.all_marked() %]
     <p>
       [%- IF all_marked %]
       <a class="btn btn-xs mark_all padding0" data-marked="1"><span class="fa fa-check-square-o fa-lg"></span> [% h.loc("mark.unmark_all") %]</a>

--- a/views/home.tt
+++ b/views/home.tt
@@ -1,5 +1,4 @@
-[% qp = request.params.hash -%]
-[% qp.delete('splat') -%]
+[%- qp = params_query -%]
 [%- style = qp.style || style || h.config.citation.csl.default_style %]
 [% backend = request.path_info.match('librecat') ? 1 : 0 -%]
 [% thisPerson = backend ? h.get_person(session.user_id) : h.get_person(id) -%]
@@ -59,7 +58,7 @@
                     [% END %]
                     [% IF backend AND session.role == "project_reviewer" %]
                     [% FOREACH project IN thisPerson.project_reviewer %]
-                    <li class="helpme[% IF modus.match(project._id) %] active[% END %]" title="[% lf.help.publication_project_reviewer %]"><a href="[% uri_base %]/librecat/search/project_reviewer/[% project._id %]">[% h.get_project(project._id).name %]</a></li>
+                    <li class="helpme[% IF modus.match(project._id) %] active[% END %]" title="[% h.loc('help.publication_project_reviewer') | html %]"><a href="[% uri_base %]/librecat/search/project_reviewer/[% project._id %]">[% h.get_project(project._id).name %]</a></li>
                     [% END %]
                     [% END %]
                     [% IF backend AND session.role == "data_manager" %]

--- a/views/inc/marked/hits.tt
+++ b/views/inc/marked/hits.tt
@@ -1,12 +1,11 @@
 <!-- BEGIN inc/marked/hits.tt -->
-
+[%- qp = params_query -%]
+[%- style = qp.style ? qp.style : h.config.citation.csl.default_style %]
 <p>
   <a class="btn btn-xs mark_all padding0" data-marked="1">
     <span class="fa fa-square-o fa-lg"></span> [% h.loc("mark.unmark_all") %]
   </a>
 </p>
-
-[%- style = style || h.config.citation.csl.default_style %]
 
 <ul class="list-unstyled" id="sortable">
 [% FOREACH entry IN hits %]

--- a/views/index.tt
+++ b/views/index.tt
@@ -2,7 +2,6 @@
 [%- qp = params_query %]
 [%- PROCESS header.tt %]
 <!-- BEGIN index.tt -->
-<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/index.tt
+++ b/views/index.tt
@@ -1,9 +1,8 @@
 [%- stats = h.get_statistics %]
-[%- qp = request.params.hash %]
-[%- qp.delete('splat') %]
+[%- qp = params_query %]
 [%- PROCESS header.tt %]
 <!-- BEGIN index.tt -->
-<span id="language_id" class="hidden">[% lang %]</span>
+<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/mark_all_js.tt
+++ b/views/mark_all_js.tt
@@ -1,4 +1,5 @@
 [%- USE JSON.Escape %]
+[%- qp = params_query -%]
 <script>
 var path = '[% request.uri_for(request.path_info) %]',
 searchParams = [% h.extract_params.json %];

--- a/views/marked/list.tt
+++ b/views/marked/list.tt
@@ -1,5 +1,4 @@
-[% qp = request.params.hash %]
-[% qp.delete('splat') %]
+[% qp = params_query %]
 [% lang = h.locale() %]
 [%- style = qp.style ? qp.style : h.config.citation.csl.default_style %]
 [% PROCESS header.tt %]

--- a/views/pagination.tt
+++ b/views/pagination.tt
@@ -1,7 +1,7 @@
 <!-- BEGIN pagination.tt -->
 
 [% IF next_page or previous_page %]
-[% qp = request.params.hash ? request.params.hash : {} ; qp.delete('splat') %]
+[%- qp = params_query -%]
 
 <div class="col-md-12">
   <ul class="pagination">

--- a/views/person/list.tt
+++ b/views/person/list.tt
@@ -1,9 +1,8 @@
-[%- qp = request.params.hash %]
-[%- qp.delete('splat') %]
+[%- qp = params_query %]
 [%- PROCESS header.tt %]
 
 <!-- BEGIN person/list.tt -->
-<span id="language_id" class="hidden">[% lang %]</span>
+<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/person/list.tt
+++ b/views/person/list.tt
@@ -2,7 +2,6 @@
 [%- PROCESS header.tt %]
 
 <!-- BEGIN person/list.tt -->
-<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/project/list.tt
+++ b/views/project/list.tt
@@ -1,6 +1,5 @@
 [% PROCESS header.tt %]
 <!-- BEGIN project/list.tt -->
-<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/publication/list.tt
+++ b/views/publication/list.tt
@@ -3,7 +3,6 @@
 [%- PROCESS header.tt %]
 [%- style = qp.style ? qp.style : h.config.citation.csl.default_style %]
 <!-- BEGIN publication/list.tt -->
-<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/publication/list.tt
+++ b/views/publication/list.tt
@@ -1,10 +1,9 @@
 [%- path_info = request.path_info %]
-[%- qp = request.params.hash %]
-[%- qp.delete('splat') %]
+[%- qp = params_query -%]
 [%- PROCESS header.tt %]
 [%- style = qp.style ? qp.style : h.config.citation.csl.default_style %]
 <!-- BEGIN publication/list.tt -->
-<span id="language_id" class="hidden">[% lang %]</span>
+<span id="language_id" class="hidden">[% h.locale() %]</span>
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->
     <div id="banner">

--- a/views/topbar.tt
+++ b/views/topbar.tt
@@ -1,6 +1,5 @@
 [%- thisPerson = h.get_person(session.user_id) -%]
-[%- qp = request.params.hash %]
-[%- qp.delete('splat') %]
+[%- qp = params_query %]
 [%- lang = h.locale() %]
 [% lf = h.config.locale.$lang -%]
 [%- style = qp.style || h.config.citation.csl.default_style -%]
@@ -20,7 +19,7 @@
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse navbar-ex1-collapse">
             <ul class="nav navbar-nav">
-                [%- style = h.extract_params.style; sort = h.extract_params.item('sort') %]
+                [%- sort = h.extract_params.item('sort') %]
                 <li class="[% IF request.path_info == "/" %] active[% END%]"><a href="[% uri_base %]/"><span class="fa fa-home"></span>[% IF session.role == 'super_admin' %]<span class="hidden-sm">[% END %][% h.loc("header.brand") %][% IF session.role == 'super_admin' %]</span>[% END %]</a></li>
                 [%- IF session.user %]
                 <li class="[% IF request.path_info.match("/librecat") AND NOT  request.path_info.match("/librecat/admin")%] active[% END%]" title="[% h.loc("help.my_dashboard") %]"><a href="[% uri_base %]/librecat?[% IF style %]style=[% style %]&[% END %][% IF sort AND sort.0 %][% FOREACH s IN sort %]sort=[% s %]&[% END %][% END %]"><span class="fa fa-edit"></span>[% h.loc("header.my_dashboard") %]</a></li>
@@ -52,13 +51,7 @@
                 [%- END %]
             </ul>
         </div><!-- /.navbar-collapse -->
-        <div class="container">
-            <div class="row">
-                <div class="col-xs-1 col-sm-2 col-md-offset-1">
-                    [% thisLang = h.locale() %]
-                </div>
-            </div>
-        </div><!-- /container -->
+        <!-- /container -->
     </nav>
     <div class="modal" id="selectAFF">
         <div class="modal-dialog">


### PR DESCRIPTION
* `params` in Template Toolkit is not a method like in Dancer, because Dancer adds the result from `params()`. So I added these tokens (not as a method):

  * `params_query`
  * `params_body`
  * `params_route`

* I replace `request.params.hash` in the views by `params_query` (which is always a hash)

* question: still necessary to directly use `config.locale.$lang`? Better not use `h.locale()` everywhere? I left it alone, but it is widely used in all field generators. Makes it hard to be replaced in this case.

* `div` with id `language_id` still necessary?

* `qp` is sometimes the query parameters, and sometimes `h.extract_params`. What is the difference?