### PR TITLE
Fix auto locale

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,7 @@ session_state:
     ## Turn in in https installations
     # secure: 1
     expires: 1209600
+    samesite: Strict
 session_store:
   package: "Plack::Session::Store::Catmandu"
   options:

--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -360,7 +360,10 @@ sub show_locale {
 }
 
 sub locale {
-    my $param_lang = params("query")->{lang};
+    #no dancer request during test in t/LibreCat/App/Helper.t, so call to "params" fails
+    my $request = request();
+    my $param_lang = $request ?
+        params("query")->{lang} : undef;
     $_[0]->locale_exists(
         $param_lang
     ) ? $param_lang :

--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -501,20 +501,6 @@ hook before_template => sub {
     $_[0]->{uri_base} = $h->uri_base();
 
 };
-hook before => sub {
-
-    #set lang when sent
-    {
-        my $lang = param("lang");
-        if ( request->is_get() && $h->locale_exists( $lang ) ) {
-
-            $h->set_locale( $lang );
-
-        }
-
-    }
-
-};
 
 register_plugin;
 

--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -360,7 +360,11 @@ sub show_locale {
 }
 
 sub locale {
-    cookie('lang') // $_[0]->default_locale();
+    my $param_lang = params("query")->{lang};
+    $_[0]->locale_exists(
+        $param_lang
+    ) ? $param_lang :
+        cookie('lang') // $_[0]->default_locale();
 }
 
 sub set_locale {


### PR DESCRIPTION
Two things:

* I added a dancer hook in the past that changed the language in the cookie lang based on the query parameter "lang". But there is already a route /set_language for that, and it makes it hard to override the language temporarily.

* Set default cookie setting to Strict