### PR TITLE
switch between languages

### DIFF
--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -420,10 +420,7 @@ sub io_from_plack_writer {
 
 sub localize {
     my $self = shift;
-    state $locales = {};
-    my $loc = $self->locale;
-    my $i18n = $locales->{$loc} //= LibreCat::I18N->new(locale => $loc);
-    $i18n->localize(@_);
+    $self->i18n( $self->locale )->localize( @_ );
 }
 sub uri_for_locale {
     my ( $self, $locale ) = @_;
@@ -432,6 +429,16 @@ sub uri_for_locale {
     my %params = (params("query"),params("body"));
     $params{lang} = $locale;
     $request->uri_for( $path_info, \%params );
+}
+
+sub i18n {
+
+    my $self = shift;
+    my $loc  = shift // $self->locale;
+
+    state $locales = {};
+    $locales->{$loc} //= LibreCat::I18N->new(locale => $loc);
+
 }
 
 *loc = \&localize;

--- a/t/LibreCat/App/Helper.t
+++ b/t/LibreCat/App/Helper.t
@@ -300,4 +300,9 @@ is h->uri_for("/librecat",{ a => "a" }), "http://localhost:5001/librecat?a=a";
 
 }
 
+h->set_locale("de");
+is h->i18n("en")->localize("login.password"),"Password";
+is h->i18n("de")->localize("login.password"),"Passwort";
+is h->i18n()->localize("login.password"),"Passwort";
+
 done_testing;


### PR DESCRIPTION
What I did:

* introduced method `i18n( $locale )` that accepts a locale as its parameter and returns a `LibreCat::I18N` instance with that locale. Now one can switch between languages

```
# header.title: "hello [_1]"
h->i18n("en")->localize( "header.title", session.login );

# this has the same effect, but the language sticks in the cookie
h->set_locale("en")
h->localize( "header.title", session.login );
```

BTW: I could not introduce a parameter `locale/lang` into the method `localize( $key, @arguments )` as its space was already taken by the arguments..

* added tests