### PR TITLE
Fix handling of authors and editors in crossref mapping fix.

### DIFF
--- a/fixes/crossref_mapping.fix
+++ b/fixes/crossref_mapping.fix
@@ -27,24 +27,20 @@ move(ISBN, r.publication_identifier.isbn)
 replace_all(r.publication_identifier.isbn.*, '^http://id.crossref.org/isbn/(.*)',$1)
 
 # authors
-move(author, r.author)
-do list (path => r.author)
+do list (path => author, var:loop)
   do identity ()
-    move(given, first_name)
-    move(family, last_name)
-    remove(affiliation)
-    remove(sequence)
+    move(loop.given, tmp.first_name)
+    move(loop.family, tmp.last_name)
+    move(tmp,r.author.$append)
   end
 end
 
 # editors
-move(editor, r.editor)
-do list (path => r.editor)
+do list (path => editor, var:loop)
   do identity ()
-    move(given, first_name)
-    move(family, last_name)
-    remove(affiliation)
-    remove(sequence)
+    move(loop.given, tmp.first_name)
+    move(loop.family, tmp.last_name)
+    move(tmp,r.editor.$append)
   end
 end
 

--- a/fixes/crossref_mapping.fix
+++ b/fixes/crossref_mapping.fix
@@ -46,6 +46,14 @@ end
 
 add(r.publication_status, published)
 
+move(volume, r.volume)
+move(issue, r.issue)
+move(publisher, r.publisher)
+move(subtitle, r.alternative_title)
+move(subject, r.keyword)
+join(r.keyword,' ; ')
+trim(r.keyword)
+
 # type mapping
 if all_match(r.type, 'journal_article')
     move(container-title.0, r.publication)
@@ -54,6 +62,7 @@ if all_match(r.type, 'journal_article')
     else
       move(page, r.article_number)
     end
+    move(article-number, r.article_number)
 end
 
 # book
@@ -94,3 +103,5 @@ lookup(r.language.0.iso, fixes/lookup/cr_lang_iso.csv, default: eng)
 
 retain(r)
 move(r, .)
+
+vacuum()


### PR DESCRIPTION
Crossref keeps adding fields to authors/editors, which then upset the validator and kill the import. Instead of removing fields one by one, just add needed fields to tmp and discard everything else.