### PR TITLE
Fix test failures

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -22,7 +22,7 @@ requires 'Business::ISBN', 0;
 
 # Catmandu
 requires 'Catmandu', '>=1.2002';
-requires 'Catmandu::FileStore', '1.13';
+requires 'Catmandu::FileStore', '1.16';
 requires 'Catmandu::ArXiv', '0.211';
 requires 'Catmandu::BagIt' , '0.234';
 requires 'Catmandu::BibTeX', '>=0.14';

--- a/t/LibreCat/Worker/FileUploader.t
+++ b/t/LibreCat/Worker/FileUploader.t
@@ -2,6 +2,7 @@ use Catmandu::Sane;
 use Test::More;
 use Test::Exception;
 use IO::File;
+use Path::Tiny;
 use Catmandu;
 use Catmandu::DirectoryIndex::Map;
 use Catmandu::Store::DBI;
@@ -14,6 +15,8 @@ BEGIN {
 }
 
 require_ok $pkg;
+
+path('t/tmp/temp_index.db')->remove;
 
 my $temp_directory = Catmandu::DirectoryIndex::Map->new(
     base_dir => "t/tmp",

--- a/t/layer/config/catmandu.local.yml
+++ b/t/layer/config/catmandu.local.yml
@@ -227,3 +227,4 @@ log4perl: |
   log4perl.appender.FILE.filename=/dev/null
   log4perl.appender.FILE.utf8=1
   log4perl.appender.FILE.layout=SimpleLayout
+


### PR DESCRIPTION
This pr fixes tests failing in some circumstances.

* bump required version of Catmandu::FileStore
* cleanup before running t/LibreCat/Worker/FileUploader.t
* rename t/layer/config/test.yml to t/layer/config/catmandu.local.yml so that a catmandu.local.yml in the root cannot override it