### PR TITLE
escape html attributes

### DIFF
--- a/views/admin/account.tt
+++ b/views/admin/account.tt
@@ -21,7 +21,7 @@
 	<div class="col-md-5">
 	  <label for="id_q"><span class="fa fa-search"></span> Search by name or ID</label>
 	  <div class="input-group">
-	    <input type="text" class="form-control" name="q" id="id_q" placeholder="Einstein, A" value="[% qp.q %]">
+	    <input type="text" class="form-control" name="q" id="id_q" placeholder="Einstein, A" value="[% qp.q | html %]">
 	    <span class="input-group-btn">
 	      <button type="submit" class="btn btn-default"><i><span class="fa fa-search"></span> </i>Search</button>
 	    </span>

--- a/views/admin/project.tt
+++ b/views/admin/project.tt
@@ -23,7 +23,7 @@
 	<div class="col-md-5">
 	  <label for="id_q">Search Projects</label>
 	  <div class="input-group">
-	    <input type="text" class="form-control" name="q" id="id_q" value="[% qp.q %]">
+	    <input type="text" class="form-control" name="q" id="id_q" value="[% qp.q | html %]">
 	    <span class="input-group-btn">
 	      <button type="submit" class="btn btn-default"><i><span class="fa fa-search"></span> </i>Search</button>
 	    </span>

--- a/views/admin/research_group.tt
+++ b/views/admin/research_group.tt
@@ -23,7 +23,7 @@
 	<div class="col-md-5">
 	  <label for="id_q">Search Research Groups</label>
 	  <div class="input-group">
-	    <input type="text" class="form-control" name="q" id="id_q" value="[% qp.q %]">
+	    <input type="text" class="form-control" name="q" id="id_q" value="[% qp.q | html %]">
 	    <span class="input-group-btn">
 	      <button type="submit" class="btn btn-default"><i><span class="fa fa-search"></span> </i>Search</button>
 	    </span>

--- a/views/index.tt
+++ b/views/index.tt
@@ -27,7 +27,7 @@
                     <form action="[% uri_base %]/record" method="get" id="main_search_form">
                       <div class="col-lg-8 col-md-7 col-sm-6">
                         <div class="input-group">
-                          <input type="text" name="q" class="form-control" placeholder="[% h.loc("home.search_placeholder") %]">
+                          <input type="text" name="q" class="form-control" placeholder="[% h.loc("home.search_placeholder") | html %]">
                           <span class="input-group-btn">
                             <button type="submit" class="btn btn-default">[% h.loc("facets.go_button") %]</button>
                           </span>


### PR DESCRIPTION
Use case: http://demo.librecat.org/librecat/admin/account?q=james+%22dean

When you type something like `"james dean"` in the search form http://demo.librecat.org/librecat/admin/account, then query is not visible anymore in the
form. Reason: the html attribute value is not html escaped, and breaks.