### PR TITLE
User List shows same person several times

### DIFF
--- a/config/store.yml
+++ b/config/store.yml
@@ -1063,6 +1063,10 @@ search:
                 'exact': true
               field: ["first_name","old_name.first_name"]
               sort: {field: 'first_name.sort'}
+            lastname_browse:
+              op:
+                '=': true
+              field: ['last_name']
             id:
               op:
                 '=': true

--- a/lib/LibreCat/App/Search/Route/person.pm
+++ b/lib/LibreCat/App/Search/Route/person.pm
@@ -22,7 +22,7 @@ get '/person' => sub {
     my $c = params("query")->{browse} // 'a';
 
     my %search_params = (
-        cql   => ["publication_count>0 AND lastname=" . lc $c . "*"],
+        cql   => ["publication_count>0 AND lastname_browse=" . lc $c . "*"],
         sort  => h->config->{default_person_sort},
         start => 0,
         limit => 1000


### PR DESCRIPTION
The search behind the user list on the homepage uses the ```lastname``` cql parameter, which accesses both the ```last_name``` and the ```old_name.last_name``` field of the user db.

So if Marilyn Monroe had ever been married to Albert Einstein, she would be listed under "E" as well as "M". 

I've added a cql parameter called ```lastname_browse``` solely for this purpose and changed the search method in ```person.pm``` to use this instead of the more general ```lastname``` parameter.