### PR TITLE
Fix sorting by first author

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -187,7 +187,7 @@ facets:
     year: Jahr
     date_updated: Änderungsdatum
     title: Titel
-    author: Erstautor/in
+    first_contributor: Erstautor*in/-editor*in
     type: Publikationstyp
     publication: "Publ./ Serie/ Journal"
     fullname: "Alphabetisch"

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -186,7 +186,7 @@ facets:
     year: "Publishing Year"
     date_updated: "Date Updated"
     title: Title
-    author: "First Author"
+    first_contributor: "First Author/Editor"
     type: "Publication Type"
     publication: "Publ./ Series/ Journal"
     fullname: Alphabetically

--- a/config/store.yml
+++ b/config/store.yml
@@ -339,6 +339,7 @@ search:
             editor: *personField
             translator: *personField
             supervisor: *personField
+            first_contributor: {type: keyword}
             creator:
               properties:
                 id: {type: keyword}
@@ -713,6 +714,14 @@ search:
                 '<>': true
                 'exact': {field: ['author.full_name.exact', 'author.id']}
               field: ['author.full_name', 'author.id']
+            first_contributor:
+              op:
+                'any': true
+                'all': true
+                '=': true
+                '<>': true
+              field: 'first_contributor'
+              sort: true
             editor:
               op:
                 'any': true

--- a/fixes/index_publication.fix
+++ b/fixes/index_publication.fix
@@ -28,6 +28,19 @@ if exists(project)
   end
 end
 
+## add field for sorting by first author/editor
+if exists(author)
+  copy_field(author.0.full_name, first_contributor)
+else
+  if exists(translator)
+    copy_field(translator.0.full_name, first_contributor)
+  else
+    if exists(editor)
+      copy_field(editor.0.full_name, first_contributor)
+    end
+  end
+end
+
 ## add flags for ISI/PMID
 if all_match(external_id.isi.0, '^\w+$')
   add_field(isi, 1)
@@ -50,3 +63,4 @@ if all_match(status,"returned|deleted")
 else
   remove_field(oai_deleted)
 end
+


### PR DESCRIPTION
Add field first_contributor to rec at indexing time and sort by it when sorting first author.

Fixes #672 

**Needs a re-indexing!**

**Needs an addition/change in catmandu.local.yml:**
```
sort_options:
  - year
  - date_updated
  - title
  - **author**
  - type
  - publication
```
needs to be changed to
```
sort_options:
  - year
  - date_updated
  - title
  - first_contributor
  - type
  - publication
```