### PR TITLE
Fixing permissions #337

### DIFF
--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1,6 +1,9 @@
 _prefix:
   permissions:
 
+# Cache duration : how long can we keep cached permissions in memory
+cache_duration: 10 seconds
+
 # Route to the login screen
 login_route: /login
 # Cookie key that contains the logged in user details

--- a/config/permissions.yml
+++ b/config/permissions.yml
@@ -1,9 +1,6 @@
 _prefix:
   permissions:
 
-# Cache duration : how long can we keep cached permissions in memory
-cache_duration: 10 seconds
-
 # Route to the login screen
 login_route: /login
 # Cookie key that contains the logged in user details

--- a/cpanfile
+++ b/cpanfile
@@ -84,6 +84,7 @@ requires 'App::bmkpasswd', '2.010001';
 requires 'Autoload::AUTOCAN', '0.005';
 requires 'Business::ISBN10';
 requires 'Business::ISBN13';
+requires 'CHI','0.60';
 requires 'Clone';
 requires 'Code::TidyAll', 0;
 requires 'Config::Onion', '>= 1.007';

--- a/lib/LibreCat/App/Catalogue/Controller/Permission.pm
+++ b/lib/LibreCat/App/Catalogue/Controller/Permission.pm
@@ -63,8 +63,11 @@ sub _can_do_action {
 
     return 0 unless defined($user_id) && defined($role);
 
-    my $pub   = get_cached_publication($id) or return 0;
-    my $user  = get_cached_user($user_id);
+    my $pub   = $opts->{live} ? h->main_publication->get($id) : get_cached_publication($id);
+
+    is_hash_ref($pub) or return 0;
+
+    my $user  = $opts->{live} ? h->get_person( $user_id ) : get_cached_user($user_id);
 
     # do not touch deleted records
     return 0 if $pub->{status} && $pub->{status} eq 'deleted';
@@ -102,7 +105,9 @@ Publication identifier
 
 =item opts
 
-Hash reference containing "user_id" and "role". Both must be a string
+ * user_id
+ * role
+ * [live=1]
 
 =back
 
@@ -123,7 +128,9 @@ Publication identifier
 
 =item opts
 
-Hash reference containing "user_id" and "role". Both must be a string
+* user_id
+* role
+* [live=1]
 
 =back
 
@@ -144,7 +151,9 @@ Publication identifier
 
 =item opts
 
-Hash reference containing "user_id" and "role". Both must be a string
+* user_id
+* role
+* [live=1]
 
 =back
 
@@ -165,7 +174,9 @@ Publication identifier
 
 =item opts
 
-Hash reference containing "user_id" and "role". Both must be a string
+* user_id
+* role
+* [live=1]
 
 =back
 
@@ -186,7 +197,9 @@ Publication identifier
 
 =item opts
 
-Hash reference containing "user_id" and "role". Both must be a string
+* user_id
+* role
+* [live=1]
 
 =back
 
@@ -213,6 +226,7 @@ Hash reference containing:
     * role (string)
     * file_id (string)
     * ip (string)
+    * [live=1]
 
 =back
 
@@ -224,8 +238,10 @@ sub can_download {
     is_string($id)     or return (0, "");
     is_hash_ref($opts) or return (0, "");
 
-    my $pub = get_cached_publication($id) or return (0, "");
+    my $pub   = $opts->{live} ? h->main_publication->get($id) : get_cached_publication($id);
 
+    is_hash_ref($pub) or retur (0,"");
+    
     my $file_id = $opts->{file_id};
     my $user_id = $opts->{user_id};
     my $role    = $opts->{role};

--- a/lib/LibreCat/App/Catalogue/Route/file.pm
+++ b/lib/LibreCat/App/Catalogue/Route/file.pm
@@ -156,7 +156,8 @@ sub _handle_download {
             file_id => $file_id,
             user_id => session->{user_id},
             role    => session->{role},
-            ip      => request->address
+            ip      => request->address,
+            live    => 1
         }
     );
 

--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -139,7 +139,7 @@ Checks if the user has permission the see/edit this record.
         unless (
             p->can_edit(
                 $rec->{_id},
-                {user_id => session("user_id"), role => session("role")}
+                {user_id => session("user_id"), role => session("role"), live=>1}
             )
             )
         {
@@ -201,7 +201,7 @@ Checks if the user has the rights to update this record.
             $params->{finalSubmit} eq 'recPublish'
             && p->can_make_public(
                 $params->{_id},
-                {user_id => session("user_id"), role => session("role")}
+                {user_id => session("user_id"), role => session("role"), live=>1}
             )
             )
         {
@@ -211,7 +211,7 @@ Checks if the user has the rights to update this record.
             $params->{finalSubmit} eq 'recReturn'
             && p->can_return(
                 $params->{_id},
-                {user_id => session("user_id"), role => session("role")}
+                {user_id => session("user_id"), role => session("role"), live=>1}
             )
             )
         {
@@ -221,7 +221,7 @@ Checks if the user has the rights to update this record.
             $params->{finalSubmit} eq 'recSubmit'
             && p->can_submit(
                 $params->{_id},
-                {user_id => session("user_id"), role => session("role")}
+                {user_id => session("user_id"), role => session("role"), live=>1}
             )
             )
         {
@@ -230,7 +230,7 @@ Checks if the user has the rights to update this record.
         elsif (
             p->can_edit(
                 $params->{_id},
-                {user_id => session("user_id"), role => session("role")}
+                {user_id => session("user_id"), role => session("role"), live=>1}
             )
         )
         {
@@ -352,7 +352,7 @@ Checks if the user has the rights to edit this record.
         unless (
             p->can_return(
                 $rec->{_id},
-                {user_id => session("user_id"), role => session("role")}
+                {user_id => session("user_id"), role => session("role"), live=>1}
             )
             )
         {
@@ -390,7 +390,7 @@ Deletes record with id. For admins only.
         unless (
             p->can_delete(
                 $rec->{_id},
-                {user_id => session("user_id"), role => session("role")}
+                {user_id => session("user_id"), role => session("role"), live=>1}
             )
             )
         {
@@ -518,7 +518,7 @@ Publishes private records, returns to the list.
         unless (
             p->can_make_public(
                 $rec->{_id},
-                {user_id => session("user_id"), role => session("role")}
+                {user_id => session("user_id"), role => session("role"), live=>1}
             )
             )
         {

--- a/t/LibreCat/App/Catalogue/Route/file.t
+++ b/t/LibreCat/App/Catalogue/Route/file.t
@@ -159,7 +159,6 @@ note("hide record from public and try to download");
     $pubs->search_bag->add($r);
     $pubs->bag->commit();
     $pubs->search_bag->commit;
-
     $mech->max_redirect(0);
     $mech->get("/download/$record_id/$file_id/$file_name");
     is ($mech->status, 403, "forbidden: status 403");


### PR DESCRIPTION
Problem with permissions (complex and very slow)

The `can_edit` , `can_download` , etc methods have an easy interface but the details are complex. The methods get an publication id and user id as input and do some computation based on the metadata of the publication and user if this record can be edited, downloaded etc.

The lookups make this permission check very slow. There are currently two ways to solve this:

a) Rewrite the methods (and the templates) to pass publications and records by value. 
b) Use some sort of caching mechanism

The solution in the PR is b) and is copied what is already done at UGent : use a short 5 second CHI cache to catch bursts of requesting the same publication/user.

Option a) has been investigated and requires rewriting a lot of templates. This is due to the fact that the publication hash is not available in the templates but only all the individual fields. Plugins like `Template::Plugin::Stash` could help but it still requires a lot of rewriting and adding more logic in the templates. In short nor a) nor b) is a perfect solution.

In any case, the permissions that are displayed on a web page can never be truely up to date (without an Ajax like mechanism to poll constantely for permission updates). IMHO a caching of 5 seconds is not that bad.