### PR TITLE
Fix issue 772

### DIFF
--- a/config/hooks.yml
+++ b/config/hooks.yml
@@ -27,6 +27,11 @@ hooks:
     before_fixes: []
     after_fixes: []
 
+  # Code that runs when creating a publication
+  publication-create:
+    before_fixes: []
+    after_fixes: []
+
   # Code that runs at a 'Make public' action
   publication-publish:
     before_fixes: []

--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -44,8 +44,10 @@ header:
   logged_in_as: "Eingeloggt als"
 error:
   version_conflict: "Ihre Änderungen konnten nicht gespeichert werden. Diese Publikation wurde in der Zwischenzeit von jemand anderem bearbeitet."
-  update_failed: "Publikation %s konnte nicht gespeichert werden. Das Support-Team wurde benachrichtigt."
-  contact_admin: "Bitte kontaktieren Sie %s, falls das Problem bestehen bleibt."
+  update_failed: "Publikation [_1] konnte nicht gespeichert werden. Das Support-Team wurde benachrichtigt."
+  create_failed: "Publikation [_1] konnte nicht gespeichert werden. Das Support-Team wurde benachrichtigt."
+  record_id_taken: "Record [_1] has already been taken. Please reload this form to create a new record"
+  contact_admin: "Bitte kontaktieren Sie [_id], falls das Problem bestehen bleibt."
   preliminary_submit: "Das Formular wurde abgschickt bevor diese volständig geladen wurde. Alle Änderungen wurden verworfen."
 footer:
   powered_by: "Powered by <a href='http://www.librecat.org/'>LibreCat</a>"

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -44,8 +44,10 @@ header:
   logged_in_as: "Logged in as"
 error:
   version_conflict: "Could not save your changes. This publication was updated by someone else since you started editing."
-  update_failed: "Failed to update record %s. The admins have been notified."
-  contact_admin: "Please, contact %s when this problem persists."
+  update_failed: "Failed to update record [_1]. The admins have been notified."
+  create_failed: "Failed to create record [_1]. The admins have been notified."
+  record_id_taken: "Record [_1] has already been taken. Please reload this form to create a new record"
+  contact_admin: "Please, contact [_1] when this problem persists."
   preliminary_submit: "Form was submitted before it was fully loaded. All requested changes have been discarded to prevent data loss."
 footer:
   powered_by: "Powered by <a href='http://www.librecat.org/'>LibreCat</a>"

--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -16,6 +16,8 @@ use LibreCat::App::Catalogue::Controller::Permission;
 use Dancer qw(:syntax);
 use Dancer::Plugin::FlashMessage;
 use Encode qw(encode);
+use File::Spec;
+use URI::Escape qw(uri_escape);
 
 sub access_denied_hook {
     h->hook('publication-access-denied')
@@ -42,7 +44,7 @@ sub decode_file {
 
 }
 
-=head1 PREFIX /record
+=head1 PREFIX /librecat/record
 
 All actions related to a publication record are handled under this prefix.
 
@@ -50,7 +52,7 @@ All actions related to a publication record are handled under this prefix.
 
 prefix '/librecat/record' => sub {
 
-=head2 GET /new
+=head2 GET /librecat/record/new
 
 Prints a list of available publication types + import form.
 
@@ -59,8 +61,18 @@ Some fields are pre-filled.
 =cut
 
     get '/new' => sub {
-        my $type = params->{type};
-        my $user = h->get_person(session->{user_id});
+        my $params_body = params("body");
+        my $params_query = params("query");
+        my $h = h();
+        my $type = $params_query->{type};
+        my $user_id     = session("user_id");
+        my $user_login  = session("user");
+        my $user_role   = session("role");
+        my $user = $h->get_person($user_id);
+
+        var form_action => uri_for( "/librecat/record" );
+        var form_method => "POST";
+        var new_record  => 1;
 
         return template 'backend/add_new' unless $type;
 
@@ -73,25 +85,25 @@ Some fields are pre-filled.
             _id        => $id,
             type       => $type,
             department => $user->{department},
-            creator => {id => session->{user_id}, login => session->{user},},
-            user_id => session->{user_id},
+            creator => { id => $user_id, login => $user_login },
+            user_id => $user_id,
         };
 
         # Use config/hooks.yml to register functions
         # that should run before/after adding new publications
         # E.g. create a hooks to change the default fields
-        state $hook = h->hook('publication-new');
+        state $hook = $h->hook('publication-new');
 
         $hook->fix_before($data);
 
         #-- Fill out default fields ---
 
-        if (session->{role} eq "user") {
+        if ( $user_role eq "user") {
             my $person = {
                 first_name => $user->{first_name},
                 last_name  => $user->{last_name},
                 full_name  => $user->{full_name},
-                id         => session->{user_id},
+                id         => $user_id,
             };
             $person->{orcid} = $user->{orcid} if $user->{orcid};
 
@@ -109,19 +121,19 @@ Some fields are pre-filled.
             }
         }
 
-        if (h->locale_exists(param('lang'))) {
+        if ($h->locale_exists(param('lang'))) {
             $data->{lang} = param('lang');
         }
-
-        my $templatepath = "backend/forms";
-
-        $data->{new_record} = 1;
 
         # -- end default fields ---
 
         $hook->fix_after($data);
 
-        template "$templatepath/$type", $data;
+        my $template = File::Spec->catfile(
+            "backend","forms",$type
+        );
+
+        template $template, $data;
     };
 
 =head2 GET /edit/:id
@@ -154,8 +166,9 @@ Checks if the user has permission the see/edit this record.
 
         $hook->fix_before($rec);
 
-        my $templatepath = "backend/forms";
-        my $template     = $rec->{meta}->{template} // $rec->{type};
+        my $template = File::Spec->catfile(
+            "backend","forms", $rec->{type}
+        );
 
         $rec->{return_url} = request->referer if request->referer;
 
@@ -163,177 +176,42 @@ Checks if the user has permission the see/edit this record.
 
         $hook->fix_after($rec);
 
-        template "$templatepath/$template", $rec;
+        var form_action => uri_for(
+            "/librecat/record/".uri_escape(params("route")->{id}),{ "x-tunneled-method" => "PUT" }
+        );
+        var form_method => "POST";
+        var new_record  => 0;
+
+        template $template, $rec;
     };
 
 =head2 POST /update
 
-Saves the record in the database.
+Deprecated route: all trafic is internally forwarded to
 
-Checks if the user has the rights to update this record.
+* C<POST "/librecat/record"> when body parameter C<new_record> is given, or when body parameter C<_id> is missing.
+
+* C<PUT "/librecat/record/:id"> when body parameter C<_id> is given and body parameter C<new_record> is missing.
 
 =cut
 
     post '/update' => sub {
-        my $params     = params;
-        my $return_url = $params->{return_url};
+        my $params_body = params("body");
 
-        # When the form isnt fully loaded when the record is saved bail out and cry for help
-        if( $params ->{_end_} ne '_end_' ){
-            flash danger => h->localize('error.preliminary_submit');
-            return redirect $return_url || uri_for('/librecat');
+        if( $params_body->{new_record} ){
+
+            forward "/librecat/record",{},{ method => "POST" };
+
         }
 
-        delete $params->{_end_};
+        if( is_string( $params_body->{_id} ) ){
 
-        h->log->debug("Params:" . to_dumper($params));
+            forward "/librecat/record/".uri_escape( $params_body->{_id} ),{},{ method => "PUT" };
 
-        #unpack strange format of record.file
-        #TODO: this should not be necessary
-        $params->{file} = decode_file( $params->{file} );
-
-        $params->{finalSubmit} //= '';
-
-        if ($params->{new_record}) {
-            # ok
-        }
-        elsif (
-            $params->{finalSubmit} eq 'recPublish'
-            && p->can_make_public(
-                $params->{_id},
-                {user_id => session("user_id"), role => session("role"), live=>1}
-            )
-            )
-        {
-            # ok
-        }
-        elsif (
-            $params->{finalSubmit} eq 'recReturn'
-            && p->can_return(
-                $params->{_id},
-                {user_id => session("user_id"), role => session("role"), live=>1}
-            )
-            )
-        {
-            # ok
-        }
-        elsif (
-            $params->{finalSubmit} eq 'recSubmit'
-            && p->can_submit(
-                $params->{_id},
-                {user_id => session("user_id"), role => session("role"), live=>1}
-            )
-            )
-        {
-            # ok
-        }
-        elsif (
-            p->can_edit(
-                $params->{_id},
-                {user_id => session("user_id"), role => session("role"), live=>1}
-            )
-        )
-        {
-            # ok
-        }
-        else {
-            access_denied_hook();
-            status '403';
-            forward '/access_denied';
         }
 
-        $params = h->nested_params($params);
+        forward "/librecat/record",{},{ method => "POST" };
 
-        if (!$params->{finalSubmit}) {
-            librecat->log->warn("receiving an empty finalSubmit from the form");
-        }
-        elsif ($params->{finalSubmit} eq 'recSubmit') {
-            $params->{status} = 'submitted';
-        }
-        elsif ($params->{finalSubmit} eq 'recPublish') {
-            $params->{status} = 'public';
-        }
-        elsif ($params->{finalSubmit} eq 'recReturn') {
-            $params->{status} = 'returned';
-        }
-        else {
-            librecat->log->warnf(
-                "receiving an unknown finalSubmit `%s` from the form"
-                    , $params->{finalSubmit}
-            );
-        }
-
-        $params->{user_id} = session("user_id");
-
-        # Use config/hooks.yml to register functions
-        # that should run before/after updating publications
-        my $is_error_record = 0;
-        my $error_messages  = '';
-        my $is_new_record   = $params->{new_record};
-        try {
-            h->hook('publication-update')->fix_around(
-                $params,
-                sub {
-                    publication->add(
-                        $params,
-                        on_validation_error => sub {
-                            my ($rec, $errors) = @_;
-                            librecat->log->errorf(
-                                "%s not a valid publication %s",
-                                $rec->{_id} // 'NEW', [map { $_->{message} } @$errors]);
-                            $is_error_record = 1;
-                            my $current_locale = h->locale();
-                            $error_messages  = [ map {
-                                $_->localize( $current_locale );
-                            } @$errors ];
-                        }
-                    );
-                }
-            );
-        }
-        catch {
-            if (is_instance($_, 'LibreCat::Error::VersionConflict')) {
-                flash warning => h->localize("error.version_conflict");
-            }
-            else {
-                my $id = $params->{_id};
-                h->log->fatal("failed to update record $id");
-                h->log->fatal($_);
-
-                my $admin_email = h->config->{admin_email};
-
-                $is_error_record = 1;
-                $error_messages  = [
-                    sprintf(h->localize("error.update_failed"), $id) . " "
-                        . sprintf(
-                        h->localize("error.contact_admin"),
-                        $admin_email
-                        )
-                ];
-            }
-        };
-
-        # When we have an error record we return to the edit form and show
-        # all errors...
-        if ($is_error_record) {
-
-            # The new_record is a field not available in the schema
-            # which will be removed after validation. We need to se
-            # it again
-            $params->{new_record} = 1 if $is_new_record;
-
-            my $templatepath = "backend/forms";
-            my $template     = $params->{meta}->{template} // $params->{type};
-
-            flash danger => join("<br>", @{$error_messages // []});
-
-            template "$templatepath/$template", $params;
-        }
-
-        # Else we return to the return url
-        else {
-            redirect $return_url || uri_for('/librecat');
-        }
     };
 
 =head2 GET /return/:id
@@ -583,6 +461,285 @@ Changes the type of the publication.
         $hook->fix_after($params);
 
         template "backend/forms/$params->{type}", $params;
+    };
+
+=head2 POST /librecat/record
+
+Saves a new record in the database.
+
+=cut
+
+    post "/" => sub {
+
+        my $params_query = params("query");
+        my $params_body  = params("body");
+        my $request      = request();
+        my $return_url   = is_string( $params_body->{return_url} ) ?
+            $params_body->{return_url} : $request->uri_for("/librecat");
+        delete $params_body->{return_url};
+        my $h = h();
+        my $librecat = librecat();
+        my $model = publication();
+
+        $h->log->debug( "Body parameters:" . to_dumper($params_body) );
+
+        #record should not be present
+        if( $model->get( $params_body->{_id} ) ){
+
+            flash danger => $h->localize( "error.record_id_taken", $params_body->{_id} );
+            return redirect $return_url;
+
+        }
+
+        # When the form isn't fully loaded when the record is saved bail out and cry for help
+        if( $params_body->{_end_} ne "_end_" ){
+            flash danger => $h->localize("error.preliminary_submit");
+            return redirect $return_url;
+        }
+        delete $params_body->{_end_};
+
+        #unpack strange format of record.file
+        #TODO: this should not be necessary
+        $params_body->{file} = decode_file( $params_body->{file} );
+
+        my $body = $h->nested_params( $params_body );
+
+        #user that last updated this record
+        $body->{user_id} = session("user_id");
+
+        #this used to live in the form..
+        $body->{status} = "private";
+
+        # Use config/hooks.yml to register functions
+        # that should run before/after updating publications
+        my @error_messages;
+
+        try {
+            $h->hook("publication-create")->fix_around(
+                $body,
+                sub {
+                    $model->add(
+                        $body,
+                        on_validation_error => sub {
+                            my($rec, $errors) = @_;
+                            $librecat->log->errorf(
+                                "%s not a valid publication %s",
+                                $rec->{_id},
+                                [map { $_->localize() } @$errors]
+                            );
+                            my $current_locale = $h->locale();
+                            @error_messages  = map {
+                                $_->localize( $current_locale );
+                            } @$errors;
+                        }
+                    );
+                }
+            );
+        }
+        catch {
+
+            $h->log->fatal("failed to create record");
+            $h->log->fatal($_);
+
+            push @error_messages,
+                $h->localize( "error.create_failed", $body->{_id} ) . " " .
+                $h->localize( "error.contact_admin",$h->config->{admin_email} );
+
+        };
+
+        #all is well
+        return redirect $return_url if scalar( @error_messages ) == 0;
+
+        # When we have an error record we return to the edit form and show
+        # all errors...
+        my $template = File::Spec->catfile(
+            "backend","forms", $body->{type}
+        );
+
+        flash danger => join( "<br>", @error_messages );
+
+        var form_action => $request->uri_for( "/librecat/record" );
+        var form_method => "POST";
+        var new_record  => 1;
+
+        template $template, $body;
+
+    };
+
+=head2 PUT /librecat/record/:id
+
+Updates an existing record in the database
+
+Checks if the user has the rights to update this record.
+
+All data must be supplied
+
+If record does not exist, then this route does not match
+
+=cut
+
+    put "/:id" => sub {
+
+        my $id = params("route")->{id};
+        my $params_query = params("query");
+        my $params_body  = params("body");
+        my $request      = request();
+        my $return_url   = is_string( $params_body->{return_url} ) ?
+            $params_body->{return_url} : $request->uri_for("/librecat");
+        delete $params_body->{return_url};
+        my $h       = h();
+        my $p       = p();
+        my $model   = publication();
+        my $librecat = librecat();
+
+        #record not found
+        pass unless $model->get( $id );
+
+        $h->log->debug( "Body parameters:" . to_dumper($params_body) );
+
+        # When the form isn't fully loaded when the record is saved bail out and cry for help
+        if( $params_body->{_end_} ne "_end_" ){
+            flash danger => $h->localize("error.preliminary_submit");
+            return redirect $return_url;
+        }
+        delete $params_body->{_end_};
+
+        #unpack strange format of record.file
+        #TODO: this should not be necessary
+        $params_body->{file} = decode_file( $params_body->{file} );
+
+        my $body = $h->nested_params( $params_body );
+
+        #just to make sure..
+        $body->{_id} = $id;
+
+        #user that last updated this record
+        $body->{user_id} = session("user_id");
+
+        my $finalSubmit = delete $body->{finalSubmit};
+        $finalSubmit    = is_string( $finalSubmit ) ? $finalSubmit : "";
+
+        if(
+            $finalSubmit eq "recPublish" &&
+            $p->can_make_public(
+                $id,
+                { user_id => session("user_id"), role => session("role"), live => 1 }
+            )
+        ){
+            # ok
+        }
+        elsif(
+            $finalSubmit eq "recReturn" &&
+            $p->can_return(
+                $id,
+                { user_id => session("user_id"), role => session("role"), live => 1 }
+            )
+        ){
+            # ok
+        }
+        elsif(
+            $finalSubmit eq "recSubmit" && $p->can_submit(
+                $id,
+                { user_id => session("user_id"), role => session("role"), live => 1 }
+            )
+        ){
+            # ok
+        }
+        elsif(
+            $p->can_edit(
+                $id,
+                { user_id => session("user_id"), role => session("role"), live => 1 }
+            )
+        ){
+            # ok
+        }
+        else {
+            access_denied_hook();
+            status "403";
+            forward "/access_denied";
+        }
+
+        if( $finalSubmit eq "" ){
+            $librecat->log->warn("receiving an empty finalSubmit from the form");
+        }
+        elsif( $finalSubmit eq "recSubmit" ){
+            $body->{status} = "submitted";
+        }
+        elsif( $finalSubmit eq "recPublish" ){
+            $body->{status} = "public";
+        }
+        elsif( $finalSubmit eq "recReturn" ){
+            $body->{status} = "returned";
+        }
+        else{
+            $librecat->log->warnf(
+                "receiving an unknown finalSubmit `%s` from the form", $finalSubmit
+            );
+        }
+
+        # Use config/hooks.yml to register functions
+        # that should run before/after updating publications
+        my @error_messages;
+
+        try {
+            $h->hook("publication-update")->fix_around(
+                $body,
+                sub {
+                    publication->add(
+                        $body,
+                        on_validation_error => sub {
+                            my($rec, $errors) = @_;
+                            $librecat->log->errorf(
+                                "%s not a valid publication %s",
+                                $id,
+                                [map { $_->localize() } @$errors]
+                            );
+                            my $current_locale = $h->locale();
+                            @error_messages  = map {
+                                $_->localize( $current_locale );
+                            } @$errors;
+                        }
+                    );
+                }
+            );
+        }
+        catch {
+
+            if( is_instance($_, "LibreCat::Error::VersionConflict") ){
+                flash warning => $h->localize("error.version_conflict");
+            }
+            else{
+
+                $h->log->fatal("failed to update record $id");
+                $h->log->fatal($_);
+
+                push @error_messages,
+                    $h->localize( "error.update_failed",$id ) . " " .
+                    $h->localize( "error.contact_admin",$h->config->{admin_email} );
+
+            }
+
+        };
+
+        #all is well
+        return redirect( $return_url ) if scalar( @error_messages ) == 0;
+
+        # When we have an error record we return to the edit form and show
+        # all errors...
+        my $template = File::Spec->catfile(
+            "backend","forms", $body->{type}
+        );
+
+        flash danger => join( "<br>", @error_messages );
+
+        var form_action => $request->uri_for(
+            "/librecat/record/".uri_escape($id),{ "x-tunneled-method" => "PUT" }
+        );
+        var form_method => "POST";
+        var new_record  => 0;
+
+        template $template, $body;
+
     };
 
 };

--- a/views/backend/generator/fields/buttonrow_tab.tt
+++ b/views/backend/generator/fields/buttonrow_tab.tt
@@ -10,7 +10,7 @@
 	      [%- ELSE %]
       	  <a href="[% uri_base %]/librecat/record/new" class="btn btn-warning"><span class="fa fa-times"></span> [% h.loc("forms.button.cancel") %]</a>
 	      [%- END %]
-        [%- UNLESS new_record %]
+        [%- UNLESS vars.new_record %]
             [% IF p.can_make_public( _id, user_id = session.user_id, role = session.role ) %]
             <button disabled type="submit" name="finalSubmit" value="recPublish" class="btn btn-success change_tab"><span class="fa fa-cloud-upload"></span> [% h.loc("forms.button.publish") %]</button>
             [%- END %]

--- a/views/backend/generator/master.tt
+++ b/views/backend/generator/master.tt
@@ -28,12 +28,11 @@
 
   <div class="row"></div>
 
-  <form action="[% uri_base %]/librecat/record/update" method="POST" id="edit_form">
+  <form action="[% vars.form_action | html %]" method="[% vars.form_method %]" id="edit_form">
     <input type="hidden" name="type" value="[% type %]" id="id_type"/>
     <input type="hidden" name="_id" value="[% _id %]"/>
     <input type="hidden" name="_version" value="[% _version %]"/>
-    <input type="hidden" name="status" value="[% IF !status OR status == "new" %]private[% ELSE %][% status %][% END %]"/>
-    <input type="hidden" name="new_record" value="[% new_record %]"/>
+    <input type="hidden" name="status" value="[% status %]"/>
     <input type="hidden" name="date_created" value="[% date_created %]" />
     <input type="hidden" name="creator.login" value="[% creator ? creator.login : thisPerson.login %]" />
     <input type="hidden" name="creator.id" value="[% creator ? creator.id : thisPerson._id %]" />


### PR DESCRIPTION
What I've done:

* Split route `post "/librecat/record/update"` in two routes:
  * `post "/librecat/record"`:
    * supplied `_id` should not have a corresponding record in the database yet.
    * `status` is set to `private`. This used to live in template `backend/generator/master`.
  * `put "/librecat/record/:id"`:
    * supplied `_id`must have a corresponding record in the database
    * Rules about `finalSubmit` apply only here
    * versionconflict can only happen here, not during a record creation.

* added dancer `var` to supply extra information to the form template so it can make decision like:
  * the action of the form: `var form_action => ..`
  * the method of the form: `var form_method => ..`
  * new_record: `var new_record => 0|1`
 
   These variables are accessible in template using the keyword `vars`.
   The form method `PUT` is normally not possible, but thanks to the already existing middleware `Plack::Middleware::MethodOverride` one can add the parameter `x-tunneled-method`, and use `POST` in the actual form.

* Only use body parameters when updating/creating records.

* Removed unused rule `$params->{meta}->{template}` (https://github.com/LibreCat/LibreCat/blob/master/lib/LibreCat/App/Catalogue/Route/publication.pm#L299)

* replaced `sprintf` methods by localize with parameters. See also the changes in `config/locale.en.yml` and `config/locale.de.yml`! I could not provide the German translations, so I've put English in locale.de.yml..

* Updated route `post /change_type`

* Updated route `get /clone/:id`