### PR TITLE
add missing jsonschema errors

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -1928,3 +1928,74 @@ licenses:
     short: "MPL 2.0"
     deed_url: "https://opensource.org/licenses/MPL-2.0"
     legal_code_url: "https://www.mozilla.org/en-US/MPL/2.0/"
+
+validator:
+  jsonschema:
+    errors: &jsonschema_errors
+      object:
+        required: "[_1] ist ein Pflichtattribut"
+        additionalProperties: "Attribut nicht erlaubt: [_2]"
+        maxProperties: "Zu viele Attribute in [_1]: erhalten [_2], maximal [_3] erlaubt"
+        minProperties: "Zu wenige Attribute in [_1]: erhalten [_2], mindestens [_3] erforderlich"
+      string:
+        type: "[_1] muss String sein, ist aber [_2]"
+        pattern: "[_1] passt nicht auf Muster [_2]"
+        maxLength: "[_1] ist zu lang: [_2] Zeichen, maximal [_3] Zeichen erlaubt"
+        minLength: "[_1] ist zu kurz: [_2] Zeichen, mindestens [_3] Zeichen erforderlich"
+      array:
+        type: "[_1] muss ein Array sein, ist aber ein [_2]"
+        uniqueItems: "[_1] muss eindeutige Werte enthalten"
+        additionalItems: "[_1] enthält eine ungültige Anzahl an Einträgen: [_2] Einträge, maximal [_3] Einträge erlaubt"
+        maxItems: "[_1] hat zu viele Einträge: [_2] Einträge, maximal [_3] Einträge erlaubt"
+        minItems: "[_1] hat z wenige Einträge: [_2] Einträge, mindestens [_3] erforderlich"
+      oneOf:
+        type: "[_1] muss [_2] sein, ist aber [_3]"
+        all_rules_match: "Es kann nur eine Regel zutreffen"
+      allOf:
+        type: "[_1] muss [_2] sein, ist aber [_3]"
+      anyOf:
+        type: "[_1] muss [_2] sein, ist aber [_3]"
+      enum:
+        enum: "Erlaubte Werte für [_1]: [_2]"
+      const:
+        const: "[_1] ist nicht der konstante Wert [_2]"
+      integer:
+        type: "[_1] muss Integer sein, ist aber [_2]"
+        #[_2]: received value
+        maximum: "[_1] darf nicht größer als [_3] sein"
+        minimum: "[_1] darf nicht kleiner als [_3] sein"
+        multipleOf: "[_1] muss ein Vielfaches von [_1] sein"
+        ex_minimum: "[_1] muss echt größer als [_3] sein, ist aber [_2]"
+        ex_maximum: "[_1] muss echt kleiner als [_3] sein, ist aber [_2]"
+      number:
+        type: "[_1] muss Number sein, ist aber [_2]"
+        maximum: "[_1] darf nicht größer als [_3] sein"
+        minimum: "[_1] darf nicht kleiner als [_3] sein"
+        multipleOf: "[_1] muss ein Vielfaches von [_1] sein"
+        ex_minimum: "[_1] muss echt größer als [_3] sein, ist aber [_2]"
+        ex_maximum: "[_1] muss echt kleiner als [_3] sein, ist aber [_2]"
+      not:
+        not: "[_1] darf nicht vorkommen"
+      "null":
+        "null": "[_1] muss 'null' sein"
+      format:
+        email: "[_1] ist nicht im Email-Format"
+        idn-email: "[_1] ist nicht im IDN-Email-Format"
+        hostname: "[_1] ist nicht im Hostname-Format"
+        idn-hostname: "[_1] ist nicht im IDN-Hostname-Format"
+        time: "[_1] ist nicht im Zeit-Format"
+        date: "[_1] ist kein valides Datum"
+        date-time: "[_1] ist kein valides 'Date-Time'"
+        ipv4: "[_1] ist keine valide IPv4-Adresse"
+        ipv6: "[_1] ist keine valide IPv6-Adresse"
+        uri-reference: "[_1] ist keine valide URI-REFERENCE"
+        uri: "[_1] ist kein valider URI"
+        iri: "[_1] ist kein valider IRI"
+        iri-reference: "[_1] is keine valide IRI-REFERENCE"
+        regex: "[_1] ist kein valider regulärer Ausdruck"
+        json-pointer: "[_1] ist kein valider json-pointer"
+        relative-json-pointer: "[_1] ist kein valider relative-json-pointer"
+        uri-template: "[_1] ist kein valides URI-TEMPLATE"
+
+  json_api_v1:
+    errors: *jsonschema_errors

--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -1947,7 +1947,7 @@ validator:
         uniqueItems: "[_1] muss eindeutige Werte enthalten"
         additionalItems: "[_1] enthält eine ungültige Anzahl an Einträgen: [_2] Einträge, maximal [_3] Einträge erlaubt"
         maxItems: "[_1] hat zu viele Einträge: [_2] Einträge, maximal [_3] Einträge erlaubt"
-        minItems: "[_1] hat z wenige Einträge: [_2] Einträge, mindestens [_3] erforderlich"
+        minItems: "[_1] hat zu wenige Einträge: [_2] Einträge, mindestens [_3] erforderlich"
       oneOf:
         type: "[_1] muss [_2] sein, ist aber [_3]"
         all_rules_match: "Es kann nur eine Regel zutreffen"

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -1981,16 +1981,38 @@ validator:
         #[_2]: received value
         maximum: "[_1] should not be bigger than [_3]"
         minimum: "[_1] should not be smaller than [_3]"
-        multipleOf: "[_1 ] should contain a multiple of [_1]"
+        multipleOf: "[_1] should contain a multiple of [_1]"
+        ex_minimum: "[_1] should contain a value bigger than exclusive minimum [_3], got [_2]"
+        ex_maximum: "[_1] should contain a value smaller than exclusive maximum [_3], got [_2]"
       number:
         type: "[_1] must be number, got [_2]"
         maximum: "[_1] should not be bigger than [_3]"
         minimum: "[_1] should not be smaller than [_3]"
         multipleOf: "[_1 ] should contain a multiple of [_1]"
+        ex_minimum: "[_1] should contain a value bigger than exclusive minimum [_3], got [_2]"
+        ex_maximum: "[_1] should contain a value smaller than exclusive maximum [_3], got [_2]"
       not:
         not: "[_1] should not match"
       "null":
         "null": "[_1] should be null"
+      format:
+        email: "[_1] does not match email format"
+        idn-email: "[_1] does not match idn-email format"
+        hostname: "[_1] does not match hostname format"
+        idn-hostname: "[_1] does not match idn-hostname format"
+        time: "[_1] does not match time format"
+        date: "[_1] is not a valid date"
+        date-time: "[_1] is not a valid date-time"
+        ipv4: "[_1] is not a valid ipv4 address"
+        ipv6: "[_1] is not a valid ipv6 address"
+        uri-reference: "[_1] is not a valid URI-REFERENCE"
+        uri: "[_1] is not a valid URI"
+        iri: "[_1] is not a valid IRI"
+        iri-reference: "[_1] is not a valid IRI-REFERENCE"
+        regex: "[_1] is not a valid regular expression"
+        json-pointer: "[_1] is not a valid json-pointer"
+        relative-json-pointer: "[_1] is not a valid relative-json-pointer"
+        uri-template: "[_1] is not a valid URI-TEMPLATE"
 
   json_api_v1:
     errors: *jsonschema_errors

--- a/cpanfile
+++ b/cpanfile
@@ -37,7 +37,7 @@ requires 'Catmandu::RIS', '>=0.04';
 requires 'Catmandu::SRU','0.039';
 requires 'Catmandu::Store::ElasticSearch', '>=1.0';
 requires 'Catmandu::Template', '>=0.13';
-requires 'Catmandu::Validator::JSONSchema','>=0.13';
+requires 'Catmandu::Validator::JSONSchema','>=0.15';
 requires 'Catmandu::XML';
 requires 'Search::Elasticsearch', '>=6.00';
 requires 'Search::Elasticsearch::Client::6_0';

--- a/t/www/api.t
+++ b/t/www/api.t
@@ -218,7 +218,7 @@ subtest 'jsonapi' => sub{
                errors => [
                   {
                      status => "400",
-                     title => "properties not allowed: _id/account_status/date_created/date_updated/first_name/full_name/last_name/login/password/super_admin",
+                     title => "properties not allowed: _id, account_status, date_created, date_updated, first_name, full_name, last_name, login, password, super_admin",
                      source => {
                         pointer => "/"
                      },


### PR DESCRIPTION
What I've done: added missing json schema errors

TODO: German translations

@vpeil can you copy key `validator` and everything under it from `config/locale.en.yml` into `config/locale.de.yml` en provide the German translation?