### PR TITLE
Adding a free form file.data section where any JSON can be stored #900

### DIFF
--- a/config/forms.yml
+++ b/config/forms.yml
@@ -125,7 +125,8 @@ dropzone_fields:
         - checksum
         - date_created
         - date_updated
-    # all the descriptive fields below can be edited
+        - data
+    # all the descriptive fields below can be edited in web forms
     # all other fields not in these two lists will be deleted
     descriptive:
         - relation

--- a/config/schemas.yml
+++ b/config/schemas.yml
@@ -233,6 +233,11 @@ publication:
                     #- hidden
                 type: string
                 description: "Relation upload to main record"
+            data:
+                type: string
+                # Fool's JSON match
+                pattern: '^{.*}$'
+                description: "Free JSON structured metadata (not indexed) for local usage"
             success:
                 oneOf:
                   - type: string


### PR DESCRIPTION
This is a solution for #900. A new field `data` field is added to the `file` section where any type of JSON blob can be stored for local usage. For instance, local implementers can use this field to store preservation metadata for files, or virus check information , DROID identifiers, or anything that can be imaged. 

This `file.data` can't be edited in the web forms or overwritten by these forms. The `file.data` can enter the system for instance by importing YAML files, using the `librecat publication files` command, or using the REST API.

If needed local implementers can make (parts) of this `file.data` searchable by adding the appropriate `index_publication.fix` fixes.