### PR TITLE
admin.pm: temporary hack to retrieve right user record

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/admin.pm
+++ b/lib/LibreCat/App/Catalogue/Route/admin.pm
@@ -51,7 +51,8 @@ Opens the record with ID id.
 =cut
 
     get '/account/edit/:id' => sub {
-        my $person = user->get(params->{id});
+        #temporary hack to make sure the main user table is used
+        my $person = user->bag->get(params->{id});
         template 'admin/forms/edit_account', $person;
     };
 
@@ -66,7 +67,8 @@ Redirects to /librecat/admin/account
     put '/account/:id' => sub {
 
         my $id = param("id");
-        my $user = user->get($id) or pass;
+        #temporary hack to make sure the main user table is used
+        my $user = user->bag->get($id) or pass;
 
         my $p = params("body");
         $p = h->nested_params($p);


### PR DESCRIPTION
Purpose:

The method `get` of the package `LibreCat::Model::User` does not behave like the corresponding method in the other models. Therefore the record that is retrieved in route `/librecat/admin/account/edit/:id` can be the wrong one.

That is why I explicitly use `user->bag->get` to retrieve the record that can actually be updated