### PR TITLE
Existing description of related material link was not displayed in form.

### DIFF
--- a/views/backend/generator/fields/related_material.link.tt
+++ b/views/backend/generator/fields/related_material.link.tt
@@ -104,7 +104,7 @@
       </div>
       <div class="form-group col-md-10 col-xs-11">
         <div class="input-group sticky{% IF fields.related_material.item('related_material.link').mandatory %} mandatory{% END %}">
-          <textarea name="related_material.link.0.description" placeholder="[% lf.$type.field.item('related_material.link').description.placeholder %]" class="form-control sticky"></textarea>
+          <textarea name="related_material.link.0.description" placeholder="[% lf.$type.field.item('related_material.link').description.placeholder %]" class="form-control sticky">[% IF related_material.link.0.title %][% related_material.link.0.title %] [% END %][% related_material.link.0.description %]</textarea>
           <!-- <input type="text" name="related_material.link.0.title" placeholder="[% lf.$type.field.item('related_material.link').title.placeholder %]" id="relurl_title" class="form-control sticky" value="[% related_material.link.0.title %]" /> -->
           <div class="input-group-addon"></div>
         </div>


### PR DESCRIPTION
This is a textarea and only in the case "multi_field: 0" the content of the description of the related_material.link was not displayed in the edit form.

The ```[% IF related_material.link.0.title %][% related_material.link.0.title %] [% END %]``` seems to be a relic from old times. I've included it to be consistent with the other cases in that template.