### PR TITLE
Fix radio buttons unchecking when sorting authors with drag&drop

### DIFF
--- a/public/javascripts/librecat.js
+++ b/public/javascripts/librecat.js
@@ -566,6 +566,10 @@ $(function () {
                                 var newname = $(this).attr('name').replace(/\d+/g,index);
                                 $(this).attr('name', newname);
                         }
+                        /* when we change "name", radiobuttons/checkbuttons loose their flag
+                           but the old value is still traceable..
+                           this is just a temporary fix
+                        */
                         if($(this).attr('checked') || $(this).prop('checked')){
                               $(this).removeProp('checked');
                               $(this).removeAttr('checked');

--- a/public/javascripts/librecat.js
+++ b/public/javascripts/librecat.js
@@ -566,6 +566,12 @@ $(function () {
                                 var newname = $(this).attr('name').replace(/\d+/g,index);
                                 $(this).attr('name', newname);
                         }
+                        if($(this).attr('checked') || $(this).prop('checked')){
+                              $(this).removeProp('checked');
+                              $(this).removeAttr('checked');
+                              $(this).prop('checked',true);
+                              $(this).attr('checked','checked');
+                        }
                     });
                 });
                 ui.item.removeClass("dragged").removeAttr("style");


### PR DESCRIPTION
Strange behavior in the edit forms when sorting authors by drag&drop:

Dragging an author from the bottom of the list to the top unchecks the radio buttons (extern/internal author) in every other line below the dropped author.

Dragging other authors and mixing it up with a new field unchecks several other radio buttons, even though the attribute checked="checked" remains in the source code.

There seems to be a difference in jQuery between an attribute and a property of a radio button. I did not fully understand, how to use them correctly, but my change at least fixes the problem.

(https://stackoverflow.com/questions/15844852/is-there-a-bug-with-radio-buttons-in-jquery-1-9-1)