### PR TITLE
Add parameter similar_search to helper.yml for extract_params.

### DIFF
--- a/config/helper.yml
+++ b/config/helper.yml
@@ -11,3 +11,4 @@ extract_params:
   cql: "string_array"
   sort: "string_array"
   fmt: exists
+  similar_search: exists


### PR DESCRIPTION
The similar search is activated by the parameter "similar_search" which is retrieved through h.extract_params. But the parameter was not specified in the list of parameters to extract in helper.yml.   
As a result the similar_search is never fired.