### PR TITLE
Change status of a 'new' record to 'private' when editing

### DIFF
--- a/views/backend/generator/master.tt
+++ b/views/backend/generator/master.tt
@@ -32,7 +32,7 @@
     <input type="hidden" name="type" value="[% type %]" id="id_type"/>
     <input type="hidden" name="_id" value="[% _id %]"/>
     <input type="hidden" name="_version" value="[% _version %]"/>
-    <input type="hidden" name="status" value="[% status %]"/>
+    <input type="hidden" name="status" value="[% IF !status OR status == "new" %]private[% ELSE %][% status %][% END %]"/>
     <input type="hidden" name="date_created" value="[% date_created %]" />
     <input type="hidden" name="creator.login" value="[% creator ? creator.login : thisPerson.login %]" />
     <input type="hidden" name="creator.id" value="[% creator ? creator.id : thisPerson._id %]" />


### PR DESCRIPTION
This used to be the case but the behavior was changed in a recent commit https://github.com/LibreCat/LibreCat/commit/7b260b4d1c85d5931e310f0b24398355c47057d1

Now editing a 'new' record will leave the status 'new' unless it is made public.

What was the reason for this change? Or is there maybe even a functionality in the backend logic that should still change the status to 'private' on editing, but doesn't do this correctly?