### PR TITLE
Delegate and Datamanager conflict

### DIFF
--- a/lib/LibreCat/Access.pm
+++ b/lib/LibreCat/Access.pm
@@ -79,7 +79,8 @@ sub by_user_role {
         elsif ($urole eq 'data_manager') {
             for my $id (@{$user->{data_manager}}) {
                 for my $iid (@{$pub->{department} // []}) {
-                    return 1 if $id->{_id} eq $iid->{_id};
+                    return 1 if $id->{_id} eq $iid->{_id} &&
+                    (is_same($pub->{type},'research_data') || is_same($pub->{type}, 'software'));
                     for my $tree (@{$iid->{tree} // []}) {
                         return 1 if $id->{_id} eq $tree->{_id} &&
                         (is_same($pub->{type},'research_data') || is_same($pub->{type}, 'software'));

--- a/lib/LibreCat/Access.pm
+++ b/lib/LibreCat/Access.pm
@@ -80,10 +80,10 @@ sub by_user_role {
             for my $id (@{$user->{data_manager}}) {
                 for my $iid (@{$pub->{department} // []}) {
                     return 1 if $id->{_id} eq $iid->{_id} &&
-                    (is_same($pub->{type},'research_data') || is_same($pub->{type}, 'software'));
+                    ($pub->{type} eq 'research_data' || $pub->{type} eq 'software');
                     for my $tree (@{$iid->{tree} // []}) {
                         return 1 if $id->{_id} eq $tree->{_id} &&
-                        (is_same($pub->{type},'research_data') || is_same($pub->{type}, 'software'));
+                        ($pub->{type} eq 'research_data' || $pub->{type} eq 'software');
                     }
                 }
             }

--- a/lib/LibreCat/Access.pm
+++ b/lib/LibreCat/Access.pm
@@ -76,12 +76,12 @@ sub by_user_role {
             }
         }
         elsif ($role eq 'data_manager') {
-            return 0 unless is_same($pub->{type},'research_data');
             for my $id (@{$user->{data_manager}}) {
                 for my $iid (@{$pub->{department} // []}) {
                     return 1 if $id->{_id} eq $iid->{_id};
                     for my $tree (@{$iid->{tree} // []}) {
-                        return 1 if $id->{_id} eq $tree->{_id};
+                        return 1 if $id->{_id} eq $tree->{_id} &&
+                        (is_same($pub->{type},'research_data') || is_same($pub->{type}, 'software'));
                     }
                 }
             }

--- a/lib/LibreCat/Access.pm
+++ b/lib/LibreCat/Access.pm
@@ -46,7 +46,7 @@ sub by_user_id {
 #  then the department id of the publication should match
 #  the publication record
 sub by_user_role {
-    my ($self, $pub, $user) = @_;
+    my ($self, $pub, $user, $role) = @_;
 
     return 0 unless $pub && $user;
 
@@ -55,10 +55,11 @@ sub by_user_role {
 
     my $perm_by_user_role = $self->allowed_user_role // [];
 
-    for my $role (@$perm_by_user_role) {
-        next unless $user->{$role};
+    for my $urole (@$perm_by_user_role) {
+        next unless $user->{$urole};
+        next unless $role eq $urole;
 
-        if ($role eq 'reviewer') {
+        if ($urole eq 'reviewer') {
             for my $id (@{$user->{reviewer}}) {
                 for my $iid (@{$pub->{department} // []}) {
                     return 1 if $id->{_id} eq $iid->{_id};
@@ -68,14 +69,14 @@ sub by_user_role {
                 }
             }
         }
-        elsif ($role eq 'project_reviewer') {
+        elsif ($urole eq 'project_reviewer') {
             for my $id (@{$user->{project_reviewer}}) {
                 for my $iid (@{$pub->{project} // []}) {
                     return 1 if $id->{_id} eq $iid->{_id};
                 }
             }
         }
-        elsif ($role eq 'data_manager') {
+        elsif ($urole eq 'data_manager') {
             for my $id (@{$user->{data_manager}}) {
                 for my $iid (@{$pub->{department} // []}) {
                     return 1 if $id->{_id} eq $iid->{_id};
@@ -86,7 +87,7 @@ sub by_user_role {
                 }
             }
         }
-        elsif ($role eq 'delegate') {
+        elsif ($urole eq 'delegate') {
             my @user_ids = $self->all_user_ids($pub);
 
             for my $id (@{$user->{delegate}}) {
@@ -98,7 +99,7 @@ sub by_user_role {
             }
         }
         else {
-            $self->log->error("no role_permission_map for $role!");
+            $self->log->error("no role_permission_map for $urole!");
         }
     }
 

--- a/lib/LibreCat/Access.pm
+++ b/lib/LibreCat/Access.pm
@@ -48,7 +48,7 @@ sub by_user_id {
 sub by_user_role {
     my ($self, $pub, $user, $role) = @_;
 
-    return 0 unless $pub && $user;
+    return 0 unless $pub && $user && $role;
 
     return 0 unless $self->is_publication_allowed($pub);
     return 0 if $self->is_publication_denied($pub);

--- a/lib/LibreCat/App/Catalogue/Controller/Permission.pm
+++ b/lib/LibreCat/App/Catalogue/Controller/Permission.pm
@@ -87,7 +87,7 @@ sub _can_do_action {
     if ($action_access->by_user_id($pub,$user)) {
         return 1;
     }
-    elsif ($action_access->by_user_role($pub,$user)) {
+    elsif ($action_access->by_user_role($pub,$user,$role)) {
         return 1;
     }
     else {

--- a/t/LibreCat/Access.t
+++ b/t/LibreCat/Access.t
@@ -18,7 +18,7 @@ note("basic test");
     my $x = LibreCat::Access->new;
     ok $x;
     ok !$x->by_user_id({},{});
-    ok !$x->by_user_role({},{});
+    ok !$x->by_user_role({},{},"");
 }
 
 note("user_id test");
@@ -83,7 +83,8 @@ note("user_role test");
             reviewer => [
                 { _id => 8008 }
             ]
-        }
+        },
+        'reviewer'
     );
     ok $x->by_user_role(
         {
@@ -93,17 +94,32 @@ note("user_role test");
             project_reviewer => [
                 { _id => 8008 }
             ]
-        }
+        },
+        'project_reviewer'
     );
-    ok ! $x->by_user_role(
+    ok !$x->by_user_role(
         {
-            department => [{_id => 8008}]
+            department => [{ _id => 8008, tree => [ { _id => 8008 } ] }],
+            type => 'journal_article'
         } ,
         {
             data_manager => [
                 { _id => 8008 }
             ]
-        }
+        },
+        'data_manager'
+    );
+    ok !$x->by_user_role(
+        {
+            department => [{ _id => 8008 }],
+            type => 'journal_article'
+        } ,
+        {
+            data_manager => [
+                { _id => 8008 }
+            ]
+        },
+        'data_manager'
     );
     ok $x->by_user_role(
         {
@@ -114,7 +130,8 @@ note("user_role test");
             data_manager => [
                 { _id => 8008 }
             ]
-        }
+        },
+        'data_manager'
     );
     ok $x->by_user_role(
         {
@@ -124,7 +141,19 @@ note("user_role test");
         } ,
         {
             delegate => [ 8008 ]
-        }
+        },
+        'delegate'
+    );
+    ok !$x->by_user_role(
+        {
+            creator => {
+                id => 8008
+            },
+        },
+        {
+            delegate => [ 8008 ]
+        },
+        'reviewer'
     );
 }
 


### PR DESCRIPTION
As mentioned in ticket #711 the sub ```by_user_role``` in ```/LibreCat/Access.pm``` does not consider the currently chosen user role, but only checks if the user account contains ANY role that has rights to edit this publication.

So as a reviewer for example a user would also be able to edit (e.g. from the frontdoor, where the edit link is displayed according to the result of can_edit) a publication which they only have delegate rights to.

This is not a security issue, but more of a "let's not mix up the roles" issue.

Solution:   
In ```/LibreCat/Permission.pm``` in the sub ```_can_do_action``` (which is the central sub for all the can_do_ subs), pass the current user role to the access sub ```by_user_role```.

And in ```/LibreCat/Access.pm``` in the sub ```by_user_role``` (in addition to some minor renamings) add the simple check "next unless current role eq permitted role".   
So in this sub we only accept roles that are 1. permitted for this publication, 2. roles/rights the user actually has and now 3. only the role the user has currently chosen.