### PR TITLE
Typo in arXiv mapping fix

### DIFF
--- a/fixes/arxiv_mapping.fix
+++ b/fixes/arxiv_mapping.fix
@@ -10,7 +10,7 @@ add_field(r.type, preprint)
 replace_all(id, 'http://arxiv.org/abs/(.*)v[0-9]', '$1')
 copy_field(id, r.publication)
 prepend(r.publication, 'arXiv:')
-move_field(id, external_id.arxiv.$append)
+move_field(id, r.external_id.arxiv.$append)
 
 # abstract, keywords
 move_field(summary, r.abstract.0.text)


### PR DESCRIPTION
Arxiv ID missing in arXiv imports. 

Should be ```r.external_id.arxiv``` instead of ```external_id.arxiv```