### PR TITLE
Change redirect after login form submit

### DIFF
--- a/lib/LibreCat/App.pm
+++ b/lib/LibreCat/App.pm
@@ -218,7 +218,12 @@ post '/login' => sub {
 
     if ($user) {
         h->login_user($user);
-        redirect uri_for($return_url);
+        if($return_url =~ /\?/){
+          redirect $return_url;
+        }
+        else {
+          redirect uri_for($return_url);
+        }
     }
     else {
         forward '/login', {error_message => 'Wrong username or password!'},

--- a/lib/LibreCat/App.pm
+++ b/lib/LibreCat/App.pm
@@ -211,19 +211,15 @@ Route where login data is sent to. On success redirects to
 
 post '/login' => sub {
     my $user = _authenticate(params->{user}, params->{pass});
-    my $return_url = params->{return_url} || '/librecat';
+    my $return_url = params->{return_url} || uri_for("/librecat")->as_string();
 
     # Deleting bad urls to external websites
-    $return_url =~ s{^[a-zA-Z:]+(\/\/)[^\/]+}{};
+    $return_url = uri_for("/librecat")->as_string()
+        unless index($return_url, request->uri_base()) == 0;
 
     if ($user) {
         h->login_user($user);
-        if($return_url =~ /\?/){
-          redirect $return_url;
-        }
-        else {
-          redirect uri_for($return_url);
-        }
+        redirect $return_url;
     }
     else {
         forward '/login', {error_message => 'Wrong username or password!'},

--- a/t/www/login.t
+++ b/t/www/login.t
@@ -11,20 +11,89 @@ use Test::WWW::Mechanize::PSGI;
 my $app = eval {do './bin/app.pl';};
 
 my $mech = Test::WWW::Mechanize::PSGI->new(app => $app);
+$mech->max_redirect(0);
 
-note("login");
+note("login fails");
 {
-    $mech->get_ok('/login');
+    $mech->get("/login");
 
     $mech->submit_form_ok(
         {
             form_number => 1,
-            fields      => {user => "einstein", pass => "einstein"},
+            fields      => {user => "__no_one__", pass => "__no_one__"}
         },
-        'submitting the login form'
+        "submitting the login form with invalid user"
     );
 
+    $mech->content_contains("Wrong username or password");
+
+}
+
+note("login successfull (without return_url)");
+{
+    $mech->get_ok("/login");
+
+    $mech->submit_form(
+        form_number => 1,
+        fields      => {user => "einstein", pass => "einstein"}
+    );
+
+    is($mech->response->code, 302, "successfull POST /login returns redirect");
+
+    like($mech->response->header("Location"), qr(/librecat), "first redirect after login  goes to /librecat");
+
+    $mech->get($mech->response->header("Location"));
+
+    like($mech->response->header("Location"), qr(/librecat/search/admin), "first redirect after login  goes to /librecat/search/admin");
+
+    $mech->get($mech->response->header("Location"));
+
     $mech->content_contains("(Admin)", "logged in successfully");
+
+    $mech->get("/logout");
+    is($mech->response->code, 302, "successfull logout");
+}
+
+note("login successfull (with external return_url)");
+{
+    $mech->get_ok("/login");
+
+    $mech->submit_form(
+        form_number => 1,
+        fields      => {
+            user => "einstein",
+            pass => "einstein",
+            return_url => "https://google.be"
+        }
+    );
+    is($mech->response->code, 302, "successfull POST /login returns redirect");
+
+    # return_url was invalid, and replaced by /librecat
+    like($mech->response->header("Location"), qr(/librecat), "first redirect after login with invalid return_url goes to /librecat");
+
+    $mech->get("/logout");
+    is($mech->response->code, 302, "successfull logout");
+}
+
+note("login successfull (with internal return_url)");
+{
+    $mech->get_ok("/login");
+
+    $mech->submit_form(
+        form_number => 1,
+        fields      => {
+            user => "einstein",
+            pass => "einstein",
+            return_url => "http://localhost:5001/librecat/admin/account"
+        }
+    );
+    is($mech->response->code, 302, "successfull POST /login returns redirect");
+
+    # return_url was valid
+    is($mech->response->header("Location"), "http://localhost:5001/librecat/admin/account", "first redirect after login with valid return_url");
+
+    $mech->get("/logout");
+    is($mech->response->code, 302, "successfull logout");
 }
 
 done_testing;


### PR DESCRIPTION
Use uri_for on redirect URI only if no params are attached.

(This problem only happens when submitting the login form! Prior redirects to shibboleth instances for example are exempt from this, because they don't submit the login form.)

When redirecting to a URL that has parameters attached, the sub ```uri_for``` does not recognize these parameters as such. The sub expects parameters to be given separately from the base URI.   
Instead, in this case, the full URL is used as $path (expecting a clean URL path). This results in undecoded questionmarks in the actual redirect URI and the user lands on a 404 page.

Example:   
Requested URL is ```http://localhost:5001/librecat/search/admin?sort=author.asc```   
User gets to the login form, logs in.

The redirect, however, will lead to: ```http://localhost:5001/librecat/search/admin%3Fsort=author.asc```