### PR TITLE
use full url in redirect; return after redirect

### DIFF
--- a/lib/LibreCat/App.pm
+++ b/lib/LibreCat/App.pm
@@ -190,7 +190,7 @@ Route the user will be sent to if login is required.
 get '/login' => sub {
 
     # what are you doing? you're already in.
-    redirect '/librecat' if session('user');
+    return redirect uri_for('/librecat') if session('user');
 
     # not logged in yet
     template 'login',
@@ -236,7 +236,7 @@ any '/logout' => sub {
 
     h->logout_user();
 
-    redirect '/';
+    redirect uri_for('/');
 };
 
 =head2 GET /set_language

--- a/lib/LibreCat/App/Search/Route/publication.pm
+++ b/lib/LibreCat/App/Search/Route/publication.pm
@@ -52,7 +52,7 @@ get "/record/:id" => sub {
         push @{$p->{cql}}, ("status=public", "altid=$escaped_id");
 
         $hits = searcher->search('publication', $p);
-        return redirect "/record/" . $hits->first->{_id}, 301
+        return redirect uri_for("/record/" . $hits->first->{_id}), 301
             if $hits->{total};
     }
 


### PR DESCRIPTION
* use full url in redirect. Not just for the sake of completeness, but also because the base url can contain a prefix, i.e. when served from behind a proxy
* return after a redirect. See this [line](https://github.com/LibreCat/LibreCat/blob/master/lib/LibreCat/App.pm#L193) for example: it still works for some reason (the redirect happens), even though the lines after it are also executed (put some log lines to prove it). I made it explicit to prevent future bugs.

BTW. I saw this [line](https://github.com/LibreCat/LibreCat/blob/master/lib/LibreCat/App/Search/Route/person.pm#L101) also:

```
redirect sprintf "%s%s", h->config->{person}->{staffdirectory},
            uri_escape($id);
```

Is is required to put a full base url in the config for this?