### PR TITLE
Fix permissions bug in edit links (search result list) for reviewers.

### DIFF
--- a/lib/LibreCat/App/Catalogue/Controller/Permission.pm
+++ b/lib/LibreCat/App/Catalogue/Controller/Permission.pm
@@ -63,7 +63,7 @@ sub _can_do_action {
 
     return 0 unless defined($user_id) && defined($role);
 
-    my $pub   = $opts->{live} ? h->main_publication->get($id) : get_cached_publication($id);
+    my $pub = $opts->{live} ? h->publication->get($id) : get_cached_publication($id);
 
     is_hash_ref($pub) or return 0;
 

--- a/lib/LibreCat/App/Catalogue/Controller/Permission.pm
+++ b/lib/LibreCat/App/Catalogue/Controller/Permission.pm
@@ -26,7 +26,7 @@ sub get_cached_publication {
 
     my $pub = cache()->get( "RECORD_${id}" );
     my $set_cache = !$pub;
-    $pub //= h->main_publication->get($id);
+    $pub //= h->publication->get($id);
 
     cache()->set( "RECORD_${id}", $pub) if $set_cache;
 
@@ -238,7 +238,7 @@ sub can_download {
     is_string($id)     or return (0, "");
     is_hash_ref($opts) or return (0, "");
 
-    my $pub   = $opts->{live} ? h->main_publication->get($id) : get_cached_publication($id);
+    my $pub   = $opts->{live} ? h->publication->get($id) : get_cached_publication($id);
 
     is_hash_ref($pub) or return (0,"");
 

--- a/views/links.tt
+++ b/views/links.tt
@@ -19,7 +19,7 @@
 
 [% IF backend %]
   <br />
-  [% IF p.can_edit( entry._id, user_id = session.user_id, role = session.role ) %]
+  [% IF p.can_edit( entry._id, user_id = session.user_id, role = session.role, live = 1 ) %]
   <a href="[% uri_base %]/librecat/record/edit/[% entry._id %]">[% h.loc("main_page.links.edit") %]</a>
   [% ELSE %]
   <strong>[% h.loc("main_page.links.edit") %]</strong>
@@ -38,10 +38,10 @@
     [% LAST %]
     [% END %]
   [% END %]
-  [% IF p.can_make_public( entry._id, user_id = session.user_id, role = session.role ) %]
+  [% IF p.can_make_public( entry._id, user_id = session.user_id, role = session.role, live = 1 ) %]
   | <a href="[% uri_base %]/librecat/record/publish/[% entry._id %]?return_url=[% request.uri | uri %]">[% h.loc("main_page.links.publish") %]</a>
   [% END %]
-  [% IF p.can_return( entry._id, user_id = session.user_id, role = session.role ) %]
+  [% IF p.can_return( entry._id, user_id = session.user_id, role = session.role, live = 1 ) %]
   | <a href="[% uri_base %]/librecat/record/return/[% entry._id %]?return_url=[% request.uri | uri %]">[% h.loc("main_page.links.return") %]</a>
   [% END %]
   [% IF session.role == "super_admin" %]

--- a/views/links.tt
+++ b/views/links.tt
@@ -19,7 +19,7 @@
 
 [% IF backend %]
   <br />
-  [% IF p.can_edit( entry._id, user_id = session.user_id, role = session.role, live = 1 ) %]
+  [% IF p.can_edit( entry._id, user_id = session.user_id, role = session.role ) %]
   <a href="[% uri_base %]/librecat/record/edit/[% entry._id %]">[% h.loc("main_page.links.edit") %]</a>
   [% ELSE %]
   <strong>[% h.loc("main_page.links.edit") %]</strong>
@@ -38,10 +38,10 @@
     [% LAST %]
     [% END %]
   [% END %]
-  [% IF p.can_make_public( entry._id, user_id = session.user_id, role = session.role, live = 1 ) %]
+  [% IF p.can_make_public( entry._id, user_id = session.user_id, role = session.role ) %]
   | <a href="[% uri_base %]/librecat/record/publish/[% entry._id %]?return_url=[% request.uri | uri %]">[% h.loc("main_page.links.publish") %]</a>
   [% END %]
-  [% IF p.can_return( entry._id, user_id = session.user_id, role = session.role, live = 1 ) %]
+  [% IF p.can_return( entry._id, user_id = session.user_id, role = session.role ) %]
   | <a href="[% uri_base %]/librecat/record/return/[% entry._id %]?return_url=[% request.uri | uri %]">[% h.loc("main_page.links.return") %]</a>
   [% END %]
   [% IF session.role == "super_admin" %]


### PR DESCRIPTION
**Problem:**   
As a reviewer for department `xyz` my list of "allowed" publications is displayed correctly. But some of the entries (if not all of them) are not editable. This happens when the entry does not have `xyz` itself as department, but some subdepartment of it.   
The reviewer role depends on the department tree to check if a publication belongs to department `xyz` and thus the reviewer has edit rights to it.

`_can_do_action` checks against publications from the main store, but this PR https://github.com/LibreCat/LibreCat/pull/804 moved the department tree from the main store to the index.

Quick fix:   
When checking for permissions in `_can_do_action`, don't check in main store, but in index. (Additionally: set "live" parameter in template.)