### PR TITLE
Adding datacite:titles element in OpenAIRE export view

### DIFF
--- a/views/export/openaire.tt
+++ b/views/export/openaire.tt
@@ -7,10 +7,12 @@
   xmlns="http://namespace.openaire.eu/schema/oaire/"
   xsi:schemaLocation="http://namespace.openaire.eu/schema/oaire/ https://www.openaire.eu/schema/repo-lit/4.0/openaire.xsd">
 
-  <datacite:title xml:lang="[% language.0.iso | xml_strict %]">[% title | xml_strict %]</datacite:title>
-  [%- IF alternative_title %]
-  <datacite:title titleType="AlternativeTitle">[% alternative_title | xml_strict %]</datacite:title>
-  [%- END %]
+  <datacite:titles>
+    <datacite:title xml:lang="[% language.0.iso | xml_strict %]">[% title | xml_strict %]</datacite:title>
+    [%- IF alternative_title %]
+    <datacite:title titleType="AlternativeTitle">[% alternative_title | xml_strict %]</datacite:title>
+    [%- END %]
+  <datacite:titles>
   <datacite:creators>
     [%- FOREACH a IN author %]
     <datacite:creator>


### PR DESCRIPTION
Dear LibreCat team,

a short PR to adding the

**datacite:titles**

element to the OpenAIRE export view.

To align with the latest _[Guidelines for institutional and thematic repository managers](https://openaire-guidelines-for-literature-repository-managers.readthedocs.io/en/latest/field_title.html)_ , which is also align with the _datacite:titles_ element since DataCite Metadata Kernel schema v4.1.

Kind regards, Andreas