### PR TITLE
h->current_style an h->default_style

### DIFF
--- a/lib/LibreCat/App/Catalogue/Route/person.pm
+++ b/lib/LibreCat/App/Catalogue/Route/person.pm
@@ -28,24 +28,28 @@ for his own publication list.
 =cut
 
     get '/preference/:delegate_id' => sub {
-        my $params;
-        $params->{delegate_id} = params->{delegate_id};
-        $params->{style} = params->{style} if params->{style};
-        $params->{'sort'} = params->{'sort'} if params->{'sort'};
+        my $qparams = params("query");
+        my $rparams = params("route");
+        my $params = +{};
+        my $current_style = h->current_style;
+        $params->{delegate_id} = $rparams->{delegate_id};
+        $params->{style} = $current_style if defined $current_style;
+        $params->{'sort'} = $qparams->{'sort'} if $qparams->{'sort'};
         forward '/librecat/person/preference', $params;
     };
 
     get '/preference' => sub {
+        my $qparams = params("query");
         my $person
-            = h->get_person(params->{delegate_id} || session('user_id'));
+            = h->get_person($qparams->{delegate_id} || session('user_id'));
         my $sort;
         my $tmp;
-        if (params->{'sort'}) {
-            if (ref params->{'sort'} ne "ARRAY") {
-                $sort = [params->{sort}];
+        if ($qparams->{'sort'}) {
+            if (ref $qparams->{'sort'} ne "ARRAY") {
+                $sort = [$qparams->{sort}];
             }
             else {
-                $sort = params->{sort};
+                $sort = $qparams->{sort};
             }
 
             foreach my $s (@$sort) {
@@ -59,11 +63,9 @@ for his own publication list.
             $person->{'sort'} = undef;
         }
 
-        if (params->{style}) {
-            $person->{style} = params->{style}
-                if array_includes(
-                keys %{h->config->{citation}->{csl}->{styles}},
-                params->{style});
+        my $current_style = h->current_style;
+        if (defined($current_style)) {
+            $person->{style} = $current_style;
         }
         else {
             $person->{style} = undef;

--- a/lib/LibreCat/App/Catalogue/Route/publication.pm
+++ b/lib/LibreCat/App/Catalogue/Route/publication.pm
@@ -322,7 +322,7 @@ Prints the frontdoor for every record.
 
         my $hits = publication->get($id);
 
-        $hits->{style}  = h->config->{citation}->{csl}->{default_style};
+        $hits->{style}  = h->default_style;
         $hits->{marked} = 0;
 
         template 'publication/record.tt', $hits;

--- a/lib/LibreCat/App/Helper.pm
+++ b/lib/LibreCat/App/Helper.pm
@@ -533,6 +533,56 @@ sub maybe_reload_session {
 
 }
 
+# TODO: sort order ok?
+sub available_styles {
+
+    my $self = $_[0];
+    state $csl_styles = [
+        sort keys %{ $self->config->{citation}{csl}{styles} || [] }
+    ];
+
+}
+
+sub default_style {
+
+    $_[0]->config->{citation}{csl}{default_style};
+
+}
+
+sub current_style {
+
+    my $self = $_[0];
+
+    my $current_style = var("current_style");
+
+    unless( defined($current_style) ){
+
+        my $p = params("query");
+        my $style = $p->{style};
+        $style = is_array_ref($style) ?
+            $style->[0] :
+            is_string($style) ? $style : undef;
+
+        if( is_string($style) ){
+
+            $style =
+                Catmandu::Util::array_includes($self->available_styles, $style) ?
+                    $style : ""; # return empty to differentiate from undef (already parsed vs not found)
+
+        }
+        else {
+
+            $style = "";
+        }
+
+        var(current_style => $style);
+        $current_style = $style;
+
+    }
+
+    is_string($current_style) ? $current_style : undef;
+}
+
 package LibreCat::App::Helper;
 
 =head1 NAME

--- a/lib/LibreCat/App/Search/Route/export.pm
+++ b/lib/LibreCat/App/Search/Route/export.pm
@@ -61,7 +61,8 @@ sub _export {
     my $options = clone($spec->{options}) || {};
 
     # Adding csl specific parameters via URL?
-    $options->{style} = $params->{style} if $params->{style};
+    my $current_style = h->current_style;
+    $options->{style} = $current_style if $current_style;
     $options->{links} = $params->{links} // 0;
 
     h->log->debug("exporting $package:" . Dancer::to_json($options));

--- a/lib/LibreCat/App/Search/Route/mark.pm
+++ b/lib/LibreCat/App/Search/Route/mark.pm
@@ -57,7 +57,7 @@ get '/marked' => sub {
             $hits = searcher->search('publication', $p);
             push @tmp_hits, @{$hits->{hits}};
         }
-        $hits->{style} = params->{style} || h->config->{default_style};
+        $hits->{style} = h->current_style || h->default_style;
 
 # sort hits according to id-order in session (making drag and drop sorting possible)
         foreach my $sh (@{session 'marked'}) {

--- a/views/admin/generator/fields/style.tt
+++ b/views/admin/generator/fields/style.tt
@@ -8,7 +8,7 @@
         <div class="input-group sticky">
           <div class="input-group-addon hidden-lg hidden-md">{% style.label %}</div>
           <select id="style_select" name="style" class="form-control">
-            [% FOREACH sty IN h.config.citation.csl.styles.keys %]
+            [% FOREACH sty IN h.available_styles %]
 	        <option value="[% sty %]"[% IF (style AND style == sty) OR (!style AND sty == "default") %] selected="selected"[% END %]>[% sty %]</option>
 	        [% END %]
 	      </select>

--- a/views/embed/iframe.tt
+++ b/views/embed/iframe.tt
@@ -1,6 +1,6 @@
 [%- qp = params_query -%]
 [% lang = h.locale() -%]
-[% style = qp.style ? qp.style : h.config.citation.csl.default_style -%]
+[% style = h.current_style() || h.default_style() -%]
 <!DOCTYPE html>
 <html>
   <head>

--- a/views/embed/javascript.tt
+++ b/views/embed/javascript.tt
@@ -1,8 +1,8 @@
 <!-- BEGIN embed/javascript.tt -->
 [%- qp = params_query -%]
 [% lang = h.locale() -%]
-document.write ('<ul[% IF qp.listyle %] style="[% qp.listyle %]"[% END %]>') ;
-[%- style = qp.style %]
+document.write ('<ul[% IF qp.listyle %] style="[% qp.listyle | html %]"[% END %]>') ;
+[%- style = h.current_style() || h.default_style() %]
 [%- FOREACH entry IN hits %]
 document.write('<li>');
   [%- IF entry.citation.$style %]

--- a/views/filters.tt
+++ b/views/filters.tt
@@ -40,12 +40,12 @@
   </div>
 [%- END %]
 
-[%- IF h.config.citation.engine == 'csl' AND qp.style AND !user_settings.style_eq_userstyle %]
+[%- IF h.config.citation.engine == 'csl' AND h.current_style AND !user_settings.style_eq_userstyle %]
   <div class="text-muted">
     [%- tmp = {}; tmp.import(qp); tmp.delete('style') %]
     <a href="[% request.uri_for(request.path_info, tmp) %]" rel="nofollow"><span class="fa fa-times"></span></a>
     <strong>[% h.loc("facets.citation_style") %]:</strong>
-    [% h.loc("styles.${qp.style}") %]
+    [% h.loc("styles.${h.current_style}") %]
   </div>
 [%- END %]
 
@@ -98,7 +98,7 @@
     <button data-toggle="collapse" data-target="#style" class="btn-link"><span class="fa fa-chevron-down fw"></span>[% h.loc("facets.citation_style") %]</button>
     <div class="facettecollapse">
     <ul id="style" class="collapse">
-      [%- FOREACH dstyle IN h.config.citation.csl.styles.keys %]
+      [%- FOREACH dstyle IN h.available_styles %]
         [%- IF dstyle == style %]
           <li><span class="text-muted">[% h.loc("styles.${dstyle}") %]</span></li>
         [%- ELSE %]

--- a/views/hits.tt
+++ b/views/hits.tt
@@ -35,7 +35,7 @@
 [%- END %]
 </div>
 
-[%- style = style || h.config.citation.csl.default_style %]
+[%- style = h.current_style || h.default_style %]
 <!-- This publication list is displayed in "[% style %]" style and sorted "[% sorto %]" -->
 [% num = total; n = 0 %]
 [% FOREACH entry IN hits %]

--- a/views/home.tt
+++ b/views/home.tt
@@ -1,5 +1,5 @@
 [%- qp = params_query -%]
-[%- style = qp.style || style || h.config.citation.csl.default_style %]
+[%- style = h.current_style || h.default_style() %]
 [% backend = request.path_info.match('librecat') ? 1 : 0 -%]
 [% thisPerson = backend ? h.get_person(session.user_id) : h.get_person(id) -%]
 [% menu = "" -%]

--- a/views/inc/marked/hits.tt
+++ b/views/inc/marked/hits.tt
@@ -1,6 +1,6 @@
 <!-- BEGIN inc/marked/hits.tt -->
 [%- qp = params_query -%]
-[%- style = qp.style ? qp.style : h.config.citation.csl.default_style %]
+[%- style = h.current_style || h.default_style %]
 <p>
   <a class="btn btn-xs mark_all padding0" data-marked="1">
     <span class="fa fa-square-o fa-lg"></span> [% h.loc("mark.unmark_all") %]

--- a/views/marked/filters.tt
+++ b/views/marked/filters.tt
@@ -23,12 +23,12 @@
   </div>
 [%- END %]
 
-[%- IF qp.style AND !user_settings.style_eq_userstyle %]
+[%- IF h.current_style AND !user_settings.style_eq_userstyle %]
   <div class="text-muted">
     [%- tmp = {}; tmp.import(qp); tmp.delete('style') %]
     <a href="[% request.uri_for(request.path_info, tmp) %]" rel="nofollow"><span class="fa fa-times"></span></a>
     <strong>[% h.loc("facets.citation_style") %]:</strong>
-    [% h.loc("styles.${qp.style}") %]
+    [% h.loc("styles.${h.current_style}") %]
   </div>
 [%- END %]
 
@@ -37,7 +37,7 @@
     <button data-toggle="collapse" data-target="#style" class="btn-link"><span class="fa fa-chevron-down fw"></span>[% h.loc("facets.citation_style") %]</button>
     <div class="facettecollapse">
     <ul id="style" class="collapse">
-      [%- FOREACH dstyle IN h.config.citation.csl.styles.keys %]
+      [%- FOREACH dstyle IN h.available_styles %]
         [%- IF dstyle == style %]
           <li><span class="text-muted">[% h.loc("styles.${dstyle}") %]</span></li>
         [%- ELSE %]

--- a/views/marked/list.tt
+++ b/views/marked/list.tt
@@ -1,6 +1,6 @@
 [% qp = params_query %]
 [% lang = h.locale() %]
-[%- style = qp.style ? qp.style : h.config.citation.csl.default_style %]
+[%- style = h.current_style || h.default_style() %]
 [% PROCESS header.tt %]
 
 <!-- BEGIN marked/list.tt -->

--- a/views/project/record.tt
+++ b/views/project/record.tt
@@ -51,7 +51,7 @@
 	[% INCLUDE project/record_details.tt %]
 	<div class="tab-pane" id="project_publications">
          [%- IF project_publication %]
-           [%- style = h.config.citation.csl.default_style %]
+           [%- style = h.default_style() %]
            [%- limit = project_publication.limit %]
            [%- hits = project_publication.hits %]
            [%- total = project_publication.total %]

--- a/views/publication/citation_box.tt
+++ b/views/publication/citation_box.tt
@@ -2,13 +2,13 @@
 <div id="citethis" class="anchor">
   <h3 id="cite">[% h.loc("frontdoor.cite_this") %]</h3>
   <ul class="nav nav-tabs">
-      [%- FOREACH style IN h.config.citation.csl.styles.keys.sort %]
+      [%- FOREACH style IN h.available_styles %]
         [%- NEXT IF style == 'short' %]
         <li [% IF loop.first %]class="active"[% END %]><a href="#[% style %]" data-toggle="tab">[% h.loc("citation.${style}") %]</a></li>
       [%- END %]
   </ul>
   <div class="tab-content">
-  [%- FOREACH style IN h.config.citation.csl.styles.keys.sort %]
+  [%- FOREACH style IN h.available_styles %]
     [%- NEXT IF style == 'short' %]
     <div id="[% style %]" class="tab-pane[% IF loop.first %] active[% END %] cmark">[% citation.$style %]</div>
   [%- END %]

--- a/views/publication/list.tt
+++ b/views/publication/list.tt
@@ -1,7 +1,7 @@
 [%- path_info = request.path_info %]
 [%- qp = params_query -%]
 [%- PROCESS header.tt %]
-[%- style = qp.style ? qp.style : h.config.citation.csl.default_style %]
+[%- style = h.current_style() || h.default_style() %]
 <!-- BEGIN publication/list.tt -->
 <div class="row"><!-- outer border -->
   <div class="col-md-11 col-sm-12"><!-- main content -->

--- a/views/topbar.tt
+++ b/views/topbar.tt
@@ -2,7 +2,7 @@
 [%- qp = params_query %]
 [%- lang = h.locale() %]
 [% lf = h.config.locale.$lang -%]
-[%- style = qp.style || h.config.citation.csl.default_style -%]
+[%- style = h.current_style || h.default_style() -%]
 
 <!-- BEGIN navbar.tt -->
 <header>


### PR DESCRIPTION
@petrakohorst @vpeil See https://github.com/LibreCat/LibreCat/pull/967

I've added some helper methods:

* `available_styles` (array reference of styles in sorted order)
* `current_style`: current_style as found in the URL. Validated as well. Returns `undef` when not found or invalid.
* `default_style`

I've used these helper methods in the controllers where now configuration checks are repeated.

I've used these helper methods in the views as `h.current_style` and `h.default_style` where applicable.
