### PR TITLE
Minor fixes to abstract field

### DIFF
--- a/config/locale.de.yml
+++ b/config/locale.de.yml
@@ -466,6 +466,7 @@ forms:
         label: "Abstract"
         label2: "Sprache"
         placeholder: "Abstract Text"
+        explain: "Verwenden Sie Markdown für Formatierungen. Klicken Sie nach dem Speichern auf den Link 'LibreCat', um sich eine Vorschau anzuzeigen und die Formatierungen zu prüfen."
       keyword: &keyword
         label: "Stichworte"
         placeholder: "Stichworte (mehrere Einträge durch Semikolon trennen, z.B. Stichwort1 ; Stichwort 2 ; Stichwort3)"

--- a/config/locale.en.yml
+++ b/config/locale.en.yml
@@ -468,6 +468,7 @@ forms:
         label: "Abstract"
         label2: "Language"
         placeholder: "Abstract Text"
+        explain: "Use Markdown for text styling. After saving click on the link 'LibreCat' to get a preview and check text styling."
       keyword: &keyword
         label: "Keywords"
         placeholder: "Keywords (multiple entries separated by semicolon, e.g. Keyword1 ; Keyword2 ; Keyword3)"

--- a/views/backend/generator/fields/abstract.tt
+++ b/views/backend/generator/fields/abstract.tt
@@ -31,6 +31,7 @@
         <div class="sticky{% IF fields.basic_fields.abstract.mandatory OR fields.supplementary_fields.abstract.mandatory %} mandatory{% END %}">
           <textarea rows="6" name="abstract.0.text" id="id_abstract_0" placeholder="[% h.loc("forms.${type}.field.abstract.placeholder") | html %]" class="sticky form-control{% IF fields.basic_fields.abstract.mandatory OR fields.supplementary_fields.abstract.mandatory %} required{% END %}"{% IF fields.basic_fields.abstract.readonly OR fields.supplementary_fields.abstract.readonly %} readonly="readonly"{% END %}></textarea>
         </div>
+        <span class="text-muted">[% h.loc("forms.${type}.field.abstract.explain") %]</span>
       </div>
     </div>
     [% ELSE %]
@@ -75,13 +76,12 @@
           <option value="[% lang %]" [% IF abstract.0.lang == lang %]selected="selected"[% END %]>[% h.loc("forms.language.${lang}") %]</option>
           [% END %]
           </select>
-          <div class="input-group-addon" onclick="add_field('abstract');"><span class="fa fa-plus"></span></div>
-          <div class="input-group-addon" onclick="remove_field(this);"><span class="fa fa-minus"></span></div>
+          <div class="input-group-addon"></div>
         </div>
       </div>
       <div class="form-group sticky_bottom col-md-10 col-xs-11">
         <div class="sticky{% IF fields.basic_fields.abstract.mandatory OR fields.supplementary_fields.abstract.mandatory %} mandatory{% END %}">
-          <textarea rows="6" name="abstract.0.text" id="id_abstract_0" placeholder="[% h.loc("forms.${type}.field.abstract.placeholder") | html %]" class="sticky form-control{% IF fields.basic_fields.abstract.mandatory OR fields.supplementary_fields.abstract.mandatory %} required{% END %}"{% IF fields.basic_fields.abstract.readonly OR fields.supplementary_fields.abstract.readonly %} readonly="readonly"{% END %}></textarea>
+          <textarea rows="6" name="abstract.0.text" id="id_abstract_0" placeholder="[% h.loc("forms.${type}.field.abstract.placeholder") | html %]" class="sticky form-control{% IF fields.basic_fields.abstract.mandatory OR fields.supplementary_fields.abstract.mandatory %} required{% END %}"{% IF fields.basic_fields.abstract.readonly OR fields.supplementary_fields.abstract.readonly %} readonly="readonly"{% END %}>[% abstract.0.text %]</textarea>
         </div>
         <span class="text-muted">[% h.loc("forms.${type}.field.abstract.explain") %]</span>
       </div>


### PR DESCRIPTION
Add variable with abstract text to field when mutiple=0 (when multiple=0, existing abstract text was not visible in the edit form)   
Remove plus and minus signs when multiple=0 (when the field is not a multi-field, there should not be plus and minus buttons)
Add explain text to locales   
Add explain text where missing in template.